### PR TITLE
Bandwidth summary exclude

### DIFF
--- a/Sources/Netfluss/AppState.swift
+++ b/Sources/Netfluss/AppState.swift
@@ -37,7 +37,8 @@ final class AppState: ObservableObject {
             "menuBarFontDesign": "monospaced",
             "adapterOrder": [],
             "adapterCustomNames": Data(),
-            "menuBarMode": "rates"
+            "menuBarMode": "rates",
+            "totalsOnlyVisibleAdapters": false
         ])
         let monitor = NetworkMonitor()
         self.monitor = monitor

--- a/Sources/Netfluss/MenuBarView.swift
+++ b/Sources/Netfluss/MenuBarView.swift
@@ -48,15 +48,17 @@ struct MenuBarView: View {
     @AppStorage("useBits") private var useBits: Bool = false
     @AppStorage("showTopApps") private var showTopApps: Bool = false
     @AppStorage("theme") private var themeName: String = "system"
+    @AppStorage("totalsOnlyVisibleAdapters") private var totalsOnlyVisibleAdapters: Bool = false
 
     var body: some View {
         let theme = AppTheme.named(themeName)
+        let adapters = filteredAdapters()
+        let headerTotals = totalsOnlyVisibleAdapters ? totals(for: adapters) : monitor.totals
         VStack(spacing: 0) {
-            TotalRatesHeader(totals: monitor.totals, useBits: useBits)
+            TotalRatesHeader(totals: headerTotals, useBits: useBits)
 
             Divider()
 
-            let adapters = filteredAdapters()
             let customNames = (try? JSONDecoder().decode([String: String].self,
                 from: UserDefaults.standard.data(forKey: "adapterCustomNames") ?? Data())) ?? [:]
             if adapters.isEmpty {
@@ -122,6 +124,16 @@ struct MenuBarView: View {
             }
         }
         return filtered
+    }
+
+    private func totals(for adapters: [AdapterStatus]) -> RateTotals {
+        var rx: Double = 0
+        var tx: Double = 0
+        for adapter in adapters {
+            rx += adapter.rxRateBps
+            tx += adapter.txRateBps
+        }
+        return RateTotals(rxRateBps: rx, txRateBps: tx)
     }
 }
 

--- a/Sources/Netfluss/PreferencesView.swift
+++ b/Sources/Netfluss/PreferencesView.swift
@@ -106,6 +106,7 @@ struct PreferencesView: View {
     @AppStorage("menuBarFontSize") private var menuBarFontSize: Double = 10.0
     @AppStorage("menuBarFontDesign") private var menuBarFontDesign: String = "monospaced"
     @AppStorage("menuBarMode") private var menuBarMode: String = "rates"
+    @AppStorage("totalsOnlyVisibleAdapters") private var totalsOnlyVisibleAdapters: Bool = false
     @State private var hiddenAdapters: Set<String> = []
     @State private var adapterNames: [String: String] = [:]
     @State private var adapterOrder: [String] = []
@@ -184,6 +185,11 @@ struct PreferencesView: View {
                         )
                     }
                 }
+
+                Toggle("Only include visible adapters in totals", isOn: $totalsOnlyVisibleAdapters)
+                Text("When enabled, the Download/Upload summary and menu bar use only adapters that are visible here.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
 
             Section("Units") {


### PR DESCRIPTION
I added the option to exclude interfaces that are not shown in the list from the summary on top / in the menubar.
Can be toggled in the Settings.
Useful when using VPN connections which would previously double the shown bandwidth on top, but I only want to see the bandwidth used on the Ethernet interface.