### PR TITLE
Replace sliding-window statistics ranges with calendar-anchored presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Latest release: **NetFluss 2.1**
 
 ![NetFluss statistics](Screenshots/statistics.webp)
 
-- Dedicated statistics window with `1H`, `24H`, `7D`, `30D`, and `1Y` ranges
+- Dedicated statistics window with calendar-anchored ranges (Today, Yesterday, This Week, This Month, This Year) and custom date range picker
 - Download and upload timelines, top adapters, and top apps
 - Improved app attribution for Safari/WebKit traffic and more reliable adapter accounting for LAN/NAS transfers
 - Optional app statistics collection with energy-conscious background sampling
@@ -70,7 +70,7 @@ Latest release: **NetFluss 2.1**
 - Top adapter ranking with automatic `Other` grouping when many interfaces are active
 - Top 10 apps for download and upload over each selected range
 - More reliable app history sampling for Safari/WebKit traffic
-- Minute-level detail for the `1H` view
+- Calendar-anchored presets and custom date range with automatic granularity selection
 - Default-off collection mode to avoid unnecessary energy use
 
 ### Speed Test

--- a/Sources/Netfluss/StatisticsManager.swift
+++ b/Sources/Netfluss/StatisticsManager.swift
@@ -39,7 +39,9 @@ final class StatisticsManager: ObservableObject {
     private let appSamplingQueue = DispatchQueue(label: "com.local.netfluss.statistics.apps", qos: .utility)
     private var appSamplingTimer: DispatchSourceTimer?
     private var appSamplingInFlight = false
-    private var currentRange: StatisticsRange = .last24Hours
+    private var currentPresetID: String? = "today"
+    private var currentCustomStart: Date?
+    private var currentCustomEnd: Date?
 
     init(monitor: NetworkMonitor) {
         self.monitor = monitor
@@ -78,8 +80,33 @@ final class StatisticsManager: ObservableObject {
         }
     }
 
-    func loadReport(for range: StatisticsRange) {
-        currentRange = range
+    func loadReport(forPreset presetID: String) {
+        currentPresetID = presetID
+        currentCustomStart = nil
+        currentCustomEnd = nil
+        let range = StatisticsRange.preset(for: presetID) ?? .today()
+        loadRange(range)
+    }
+
+    func loadReport(customStart: Date, customEnd: Date) {
+        currentPresetID = nil
+        currentCustomStart = customStart
+        currentCustomEnd = customEnd
+        let range = StatisticsRange.custom(start: customStart, end: customEnd)
+        loadRange(range)
+    }
+
+    func refreshCurrentReport() {
+        if let presetID = currentPresetID {
+            let range = StatisticsRange.preset(for: presetID) ?? .today()
+            loadRange(range)
+        } else if let start = currentCustomStart, let end = currentCustomEnd {
+            let range = StatisticsRange.custom(start: start, end: end)
+            loadRange(range)
+        }
+    }
+
+    private func loadRange(_ range: StatisticsRange) {
         isLoading = true
 
         let customAdapterNames = Self.loadAdapterNames()
@@ -100,20 +127,16 @@ final class StatisticsManager: ObservableObject {
         }
     }
 
-    func refreshCurrentReport() {
-        loadReport(for: currentRange)
-    }
-
     func enableSampleData() {
         sampleStore = StatisticsStore(archive: StatisticsDemoData.makeArchive(now: Date()))
         isShowingSampleData = true
-        loadReport(for: currentRange)
+        refreshCurrentReport()
     }
 
     func disableSampleData() {
         sampleStore = nil
         isShowingSampleData = false
-        loadReport(for: currentRange)
+        refreshCurrentReport()
     }
 
     func flushSynchronously() {

--- a/Sources/Netfluss/StatisticsModels.swift
+++ b/Sources/Netfluss/StatisticsModels.swift
@@ -131,31 +131,90 @@ struct StatisticsAppDelta: Sendable {
     let uploadBytes: UInt64
 }
 
-enum StatisticsRange: String, CaseIterable, Identifiable, Sendable {
-    case lastHour = "1H"
-    case last24Hours = "24H"
-    case last7Days = "7D"
-    case last30Days = "30D"
-    case lastYear = "1Y"
+struct StatisticsRange: Equatable, Identifiable, Sendable {
+    enum Granularity: Equatable, Sendable {
+        case minute
+        case hour
+        case day
+    }
 
-    var id: String { rawValue }
+    let id: String
+    let title: String
+    let start: Date
+    let end: Date
+    let granularity: Granularity
 
-    var title: String {
-        switch self {
-        case .lastHour: return "Last Hour"
-        case .last24Hours: return "Last 24 Hours"
-        case .last7Days: return "Last 7 Days"
-        case .last30Days: return "Last 30 Days"
-        case .lastYear: return "Last Year"
+    var bucketTitle: String {
+        switch granularity {
+        case .minute: return "Minute Traffic"
+        case .hour: return "Hourly Traffic"
+        case .day: return "Daily Traffic"
         }
     }
 
-    var bucketTitle: String {
-        switch self {
-        case .lastHour: return "Minute Traffic"
-        case .last24Hours: return "Hourly Traffic"
-        case .last7Days, .last30Days: return "Daily Traffic"
-        case .lastYear: return "Monthly Traffic"
+    static let presetIDs = ["today", "yesterday", "thisWeek", "thisMonth", "thisYear"]
+
+    static func today(now: Date = Date(), calendar: Calendar = .autoupdatingCurrent) -> StatisticsRange {
+        let start = calendar.startOfDay(for: now)
+        return StatisticsRange(id: "today", title: "Today", start: start, end: now, granularity: .hour)
+    }
+
+    static func yesterday(now: Date = Date(), calendar: Calendar = .autoupdatingCurrent) -> StatisticsRange {
+        let todayStart = calendar.startOfDay(for: now)
+        let yesterdayStart = calendar.date(byAdding: .day, value: -1, to: todayStart) ?? todayStart
+        return StatisticsRange(id: "yesterday", title: "Yesterday", start: yesterdayStart, end: todayStart, granularity: .hour)
+    }
+
+    static func thisWeek(now: Date = Date(), calendar: Calendar = .autoupdatingCurrent) -> StatisticsRange {
+        let weekInterval = calendar.dateInterval(of: .weekOfYear, for: now)
+        let start = weekInterval?.start ?? calendar.startOfDay(for: now)
+        return StatisticsRange(id: "thisWeek", title: "This Week", start: start, end: now, granularity: .day)
+    }
+
+    static func thisMonth(now: Date = Date(), calendar: Calendar = .autoupdatingCurrent) -> StatisticsRange {
+        let monthInterval = calendar.dateInterval(of: .month, for: now)
+        let start = monthInterval?.start ?? calendar.startOfDay(for: now)
+        return StatisticsRange(id: "thisMonth", title: "This Month", start: start, end: now, granularity: .day)
+    }
+
+    static func thisYear(now: Date = Date(), calendar: Calendar = .autoupdatingCurrent) -> StatisticsRange {
+        let yearInterval = calendar.dateInterval(of: .year, for: now)
+        let start = yearInterval?.start ?? calendar.startOfDay(for: now)
+        return StatisticsRange(id: "thisYear", title: "This Year", start: start, end: now, granularity: .day)
+    }
+
+    private static let shortDateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "MMM d"
+        return f
+    }()
+
+    static func custom(start: Date, end: Date, calendar: Calendar = .autoupdatingCurrent) -> StatisticsRange {
+        let span = end.timeIntervalSince(start)
+        let granularity: Granularity = span <= 2 * 86400 ? .hour : .day
+        let title = "\(shortDateFormatter.string(from: start)) – \(shortDateFormatter.string(from: end))"
+        return StatisticsRange(id: "custom", title: title, start: start, end: end, granularity: granularity)
+    }
+
+    static func preset(for id: String, now: Date = Date(), calendar: Calendar = .autoupdatingCurrent) -> StatisticsRange? {
+        switch id {
+        case "today": return today(now: now, calendar: calendar)
+        case "yesterday": return yesterday(now: now, calendar: calendar)
+        case "thisWeek": return thisWeek(now: now, calendar: calendar)
+        case "thisMonth": return thisMonth(now: now, calendar: calendar)
+        case "thisYear": return thisYear(now: now, calendar: calendar)
+        default: return nil
+        }
+    }
+
+    static func presetTitle(for id: String) -> String {
+        switch id {
+        case "today": return "Today"
+        case "yesterday": return "Yesterday"
+        case "thisWeek": return "This Week"
+        case "thisMonth": return "This Month"
+        case "thisYear": return "This Year"
+        default: return id
         }
     }
 }

--- a/Sources/Netfluss/StatisticsStore.swift
+++ b/Sources/Netfluss/StatisticsStore.swift
@@ -135,27 +135,19 @@ actor StatisticsStore {
         let appSource: [String: [String: StatisticsTrafficAmounts]]
         let relevantKeys: [String]
 
-        switch range {
-        case .lastHour:
+        switch range.granularity {
+        case .minute:
             adapterSource = archive.adapterMinute
             appSource = archive.appMinute
-            relevantKeys = Self.minuteKeys(endingAt: now, count: 60, calendar: calendar)
-        case .last24Hours:
+            relevantKeys = Self.minuteKeys(from: range.start, to: range.end, calendar: calendar)
+        case .hour:
             adapterSource = archive.adapterHourly
             appSource = archive.appHourly
-            relevantKeys = Self.hourKeys(endingAt: now, count: 24, calendar: calendar)
-        case .last7Days:
+            relevantKeys = Self.hourKeys(from: range.start, to: range.end, calendar: calendar)
+        case .day:
             adapterSource = archive.adapterDaily
             appSource = archive.appDaily
-            relevantKeys = Self.dayKeys(endingAt: now, count: 7, calendar: calendar)
-        case .last30Days:
-            adapterSource = archive.adapterDaily
-            appSource = archive.appDaily
-            relevantKeys = Self.dayKeys(endingAt: now, count: 30, calendar: calendar)
-        case .lastYear:
-            adapterSource = archive.adapterDaily
-            appSource = archive.appDaily
-            relevantKeys = Self.dayKeys(endingAt: now, count: 365, calendar: calendar)
+            relevantKeys = Self.dayKeys(from: range.start, to: range.end, calendar: calendar)
         }
 
         let adapterTotals = aggregate(items: adapterSource, keys: relevantKeys)
@@ -210,8 +202,8 @@ actor StatisticsStore {
         source: [String: [String: StatisticsTrafficAmounts]],
         keys: [String]
     ) -> [StatisticsTimelinePoint] {
-        switch range {
-        case .lastYear:
+        // For daily granularity spanning more than 90 days, roll up into monthly buckets
+        if range.granularity == .day && range.end.timeIntervalSince(range.start) > 90 * 86400 {
             var monthlyTotals: [String: StatisticsTrafficAmounts] = [:]
             for key in keys {
                 guard let bucketDate = Self.date(fromDayKey: key, calendar: calendar),
@@ -235,30 +227,28 @@ actor StatisticsStore {
                     uploadBytes: totals.uploadBytes
                 )
             }
-        case .lastHour, .last24Hours, .last7Days, .last30Days:
-            return keys.compactMap { key in
-                let date: Date?
-                switch range {
-                case .lastHour:
-                    date = Self.date(fromMinuteKey: key, calendar: calendar)
-                case .last24Hours:
-                    date = Self.date(fromHourKey: key, calendar: calendar)
-                case .last7Days, .last30Days:
-                    date = Self.date(fromDayKey: key, calendar: calendar)
-                case .lastYear:
-                    date = nil
-                }
-                guard let date, let bucket = source[key] else { return nil }
-                let totals = bucket.values.reduce(into: StatisticsTrafficAmounts()) { partial, amounts in
-                    partial.merge(amounts)
-                }
-                return StatisticsTimelinePoint(
-                    id: key,
-                    date: date,
-                    downloadBytes: totals.downloadBytes,
-                    uploadBytes: totals.uploadBytes
-                )
+        }
+
+        return keys.compactMap { key in
+            let date: Date?
+            switch range.granularity {
+            case .minute:
+                date = Self.date(fromMinuteKey: key, calendar: calendar)
+            case .hour:
+                date = Self.date(fromHourKey: key, calendar: calendar)
+            case .day:
+                date = Self.date(fromDayKey: key, calendar: calendar)
             }
+            guard let date, let bucket = source[key] else { return nil }
+            let totals = bucket.values.reduce(into: StatisticsTrafficAmounts()) { partial, amounts in
+                partial.merge(amounts)
+            }
+            return StatisticsTimelinePoint(
+                id: key,
+                date: date,
+                downloadBytes: totals.downloadBytes,
+                uploadBytes: totals.uploadBytes
+            )
         }
     }
 
@@ -446,28 +436,48 @@ actor StatisticsStore {
         return try decoder.decode(StatisticsArchive.self, from: data)
     }
 
-    private static func hourKeys(endingAt date: Date, count: Int, calendar: Calendar) -> [String] {
-        let end = calendar.dateInterval(of: .hour, for: date)?.start ?? date
-        return (0..<count).compactMap { offset in
-            let bucketDate = calendar.date(byAdding: .hour, value: -(count - 1 - offset), to: end)
-            return bucketDate.map { hourKey(for: $0, calendar: calendar) }
+    private static func hourKeys(from start: Date, to end: Date, calendar: Calendar) -> [String] {
+        let startHour = calendar.dateInterval(of: .hour, for: start)?.start ?? start
+        let endHour = calendar.dateInterval(of: .hour, for: end)?.start ?? end
+        var keys: [String] = []
+        var current = startHour
+        // Use < so ranges ending on an exact hour boundary (e.g. Yesterday
+        // ending at midnight) don't bleed into the next period's first bucket.
+        // For ranges ending mid-hour (e.g. Today at 15:30), endHour is 15:00
+        // which is still included because the current hour has data.
+        let inclusive = end != endHour
+        while inclusive ? current <= endHour : current < endHour {
+            keys.append(hourKey(for: current, calendar: calendar))
+            guard let next = calendar.date(byAdding: .hour, value: 1, to: current) else { break }
+            current = next
         }
+        return keys
     }
 
-    private static func minuteKeys(endingAt date: Date, count: Int, calendar: Calendar) -> [String] {
-        let end = calendar.dateInterval(of: .minute, for: date)?.start ?? date
-        return (0..<count).compactMap { offset in
-            let bucketDate = calendar.date(byAdding: .minute, value: -(count - 1 - offset), to: end)
-            return bucketDate.map { minuteKey(for: $0, calendar: calendar) }
+    private static func minuteKeys(from start: Date, to end: Date, calendar: Calendar) -> [String] {
+        let startMinute = calendar.dateInterval(of: .minute, for: start)?.start ?? start
+        let endMinute = calendar.dateInterval(of: .minute, for: end)?.start ?? end
+        var keys: [String] = []
+        var current = startMinute
+        while current <= endMinute {
+            keys.append(minuteKey(for: current, calendar: calendar))
+            guard let next = calendar.date(byAdding: .minute, value: 1, to: current) else { break }
+            current = next
         }
+        return keys
     }
 
-    private static func dayKeys(endingAt date: Date, count: Int, calendar: Calendar) -> [String] {
-        let end = calendar.startOfDay(for: date)
-        return (0..<count).compactMap { offset in
-            let bucketDate = calendar.date(byAdding: .day, value: -(count - 1 - offset), to: end)
-            return bucketDate.map { dayKey(for: $0, calendar: calendar) }
+    private static func dayKeys(from start: Date, to end: Date, calendar: Calendar) -> [String] {
+        let startDay = calendar.startOfDay(for: start)
+        let endDay = calendar.startOfDay(for: end)
+        var keys: [String] = []
+        var current = startDay
+        while current <= endDay {
+            keys.append(dayKey(for: current, calendar: calendar))
+            guard let next = calendar.date(byAdding: .day, value: 1, to: current) else { break }
+            current = next
         }
+        return keys
     }
 
     private static func hourKey(for date: Date, calendar: Calendar) -> String {

--- a/Sources/Netfluss/StatisticsView.swift
+++ b/Sources/Netfluss/StatisticsView.swift
@@ -24,7 +24,14 @@ struct StatisticsView: View {
     @AppStorage("collectStatistics") private var collectStatistics: Bool = false
     @AppStorage("collectAppStatistics") private var collectAppStatistics: Bool = true
 
-    @State private var range: StatisticsRange = .last24Hours
+    @State private var selectedPresetID: String? = "today"
+    @State private var customStart: Date = Calendar.current.startOfDay(for: Calendar.current.date(byAdding: .day, value: -7, to: Date()) ?? Date())
+    @State private var customEnd: Date = {
+        let cal = Calendar.current
+        let endOfDay = cal.date(bySettingHour: 23, minute: 59, second: 59, of: Date())
+        return endOfDay ?? Date()
+    }()
+    @State private var showingCustomPicker = false
     private let refreshTimer = Timer.publish(every: 30, on: .main, in: .common).autoconnect()
 
     private let byteFormatter: ByteCountFormatter = {
@@ -46,10 +53,11 @@ struct StatisticsView: View {
         .background(AppTheme.system.backgroundColor ?? Color(NSColor.windowBackgroundColor))
         .frame(minWidth: 860, minHeight: 620)
         .onAppear {
-            statisticsManager.loadReport(for: range)
-        }
-        .onChange(of: range) { newValue in
-            statisticsManager.loadReport(for: newValue)
+            if let id = selectedPresetID {
+                statisticsManager.loadReport(forPreset: id)
+            } else {
+                statisticsManager.loadReport(customStart: customStart, customEnd: customEnd)
+            }
         }
         .onChange(of: collectStatistics) { _ in
             statisticsManager.refreshCurrentReport()
@@ -102,13 +110,52 @@ struct StatisticsView: View {
                 .buttonStyle(.borderless)
                 .foregroundStyle(.secondary)
 
-                Picker("Range", selection: $range) {
-                    ForEach(StatisticsRange.allCases) { range in
-                        Text(range.rawValue).tag(range)
+                Menu {
+                    Section("Quick Filters") {
+                        ForEach(StatisticsRange.presetIDs, id: \.self) { presetID in
+                            Button {
+                                selectedPresetID = presetID
+                                statisticsManager.loadReport(forPreset: presetID)
+                            } label: {
+                                if selectedPresetID == presetID {
+                                    Label(StatisticsRange.presetTitle(for: presetID), systemImage: "checkmark")
+                                } else {
+                                    Text(StatisticsRange.presetTitle(for: presetID))
+                                }
+                            }
+                        }
                     }
+                    Section {
+                        Button {
+                            showingCustomPicker = true
+                        } label: {
+                            if selectedPresetID == nil {
+                                Label("Custom Range…", systemImage: "checkmark")
+                            } else {
+                                Text("Custom Range…")
+                            }
+                        }
+                    }
+                } label: {
+                    HStack(spacing: 5) {
+                        Text(activeRangeLabel)
+                            .font(.system(size: 13, weight: .semibold))
+                        Image(systemName: "chevron.down")
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 7)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8, style: .continuous)
+                            .fill(Color(NSColor.controlBackgroundColor))
+                    )
                 }
-                .pickerStyle(.segmented)
-                .frame(width: 336)
+                .menuStyle(.borderlessButton)
+                .fixedSize()
+                .popover(isPresented: $showingCustomPicker, arrowEdge: .bottom) {
+                    customRangePopover
+                }
             }
         }
         .padding(.horizontal, 24)
@@ -202,7 +249,7 @@ struct StatisticsView: View {
         if collectStatistics {
             return "Keep NetFluss running for a while and this view will fill in with adapter and app history."
         }
-        return "Enable statistics in Preferences to start collecting 24-hour, 7-day, 30-day, and yearly network history."
+        return "Enable statistics in Preferences to start collecting daily, weekly, monthly, and yearly network history."
     }
 
     private var sampleDataBanner: some View {
@@ -301,7 +348,8 @@ struct StatisticsView: View {
                     points: report.timeline,
                     keyPath: \.downloadBytes,
                     color: statisticsDownloadColor,
-                    systemImage: "arrow.down"
+                    systemImage: "arrow.down",
+                    range: report.range
                 )
 
                 Rectangle()
@@ -314,7 +362,8 @@ struct StatisticsView: View {
                     points: report.timeline,
                     keyPath: \.uploadBytes,
                     color: statisticsUploadColor,
-                    systemImage: "arrow.up"
+                    systemImage: "arrow.up",
+                    range: report.range
                 )
             }
         }
@@ -331,7 +380,8 @@ struct StatisticsView: View {
         points: [StatisticsTimelinePoint],
         keyPath: KeyPath<StatisticsTimelinePoint, UInt64>,
         color: Color,
-        systemImage: String
+        systemImage: String,
+        range: StatisticsRange
     ) -> some View {
         let peakBytes = max(points.map { $0[keyPath: keyPath] }.max() ?? 0, 1)
         let averageBytes = points.isEmpty ? 0 : points.reduce(0) { $0 + $1[keyPath: keyPath] } / UInt64(points.count)
@@ -548,6 +598,79 @@ struct StatisticsView: View {
         )
     }
 
+    private var activeRangeLabel: String {
+        if let id = selectedPresetID {
+            return StatisticsRange.presetTitle(for: id)
+        }
+        return customRangeLabel
+    }
+
+    private var customRangeLabel: String {
+        StatisticsRange.custom(start: customStart, end: customEnd).title
+    }
+
+    private var customRangePopover: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            HStack {
+                Image(systemName: "calendar")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(Color.accentColor)
+                Text("Custom Range")
+                    .font(.system(size: 15, weight: .semibold))
+                Spacer()
+            }
+
+            VStack(spacing: 12) {
+                HStack(spacing: 0) {
+                    Text("From")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 40, alignment: .leading)
+                    DatePicker("", selection: $customStart, in: ...customEnd, displayedComponents: [.date, .hourAndMinute])
+                        .datePickerStyle(.field)
+                        .labelsHidden()
+                        .frame(maxWidth: .infinity)
+                }
+
+                HStack(spacing: 0) {
+                    Text("To")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 40, alignment: .leading)
+                    DatePicker("", selection: $customEnd, in: customStart...Date(), displayedComponents: [.date, .hourAndMinute])
+                        .datePickerStyle(.field)
+                        .labelsHidden()
+                        .frame(maxWidth: .infinity)
+                }
+            }
+            .padding(12)
+            .background(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .fill(Color(NSColor.controlBackgroundColor))
+            )
+
+            HStack(spacing: 10) {
+                Button("Cancel") {
+                    showingCustomPicker = false
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.regular)
+
+                Spacer()
+
+                Button("Apply") {
+                    selectedPresetID = nil
+                    showingCustomPicker = false
+                    statisticsManager.loadReport(customStart: customStart, customEnd: customEnd)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.regular)
+            }
+        }
+        .padding(20)
+        .frame(width: 340)
+    }
+
     private func formattedBytes(_ bytes: UInt64) -> String {
         byteFormatter.string(fromByteCount: Int64(bytes))
     }
@@ -595,29 +718,30 @@ struct StatisticsView: View {
     }
 
     private func axisDateFormat(for range: StatisticsRange) -> Date.FormatStyle {
-        switch range {
-        case .lastHour:
+        switch range.granularity {
+        case .minute:
             return .dateTime.hour().minute()
-        case .last24Hours:
+        case .hour:
             return .dateTime.hour()
-        case .last7Days, .last30Days:
+        case .day:
+            let span = range.end.timeIntervalSince(range.start)
+            if span > 90 * 86400 {
+                return .dateTime.month(.abbreviated)
+            }
             return .dateTime.month(.abbreviated).day()
-        case .lastYear:
-            return .dateTime.month(.abbreviated)
         }
     }
 
     private func xAxisTickCount(for range: StatisticsRange) -> Int {
-        switch range {
-        case .lastHour:
+        switch range.granularity {
+        case .minute:
             return 6
-        case .last24Hours:
+        case .hour:
             return 6
-        case .last7Days:
-            return 7
-        case .last30Days:
-            return 5
-        case .lastYear:
+        case .day:
+            let days = max(Int(range.end.timeIntervalSince(range.start) / 86400), 1)
+            if days <= 7 { return days }
+            if days <= 31 { return 5 }
             return 6
         }
     }


### PR DESCRIPTION
Hey,

I added a calendar option and a "today" filter, inside the dropdown, which I think is useful. 

Here is what Claude came up with :) Feel free to check it out.

---

Replace the hardcoded StatisticsRange enum (1H, 24H, 7D, 30D, 1Y) with a struct-based model supporting calendar-anchored presets (Today, Yesterday, This Week, This Month, This Year) and an arbitrary custom date range picker.

- StatisticsRange is now a struct with start/end dates and a granularity enum (minute, hour, day) plus factory methods for each preset
- StatisticsStore key generation is date-bounded instead of count-based
- StatisticsManager tracks preset ID separately so refreshes rebuild the range from the current time (Today keeps extending as time passes)
- StatisticsView uses a compact dropdown menu for range selection with a custom range popover featuring date+time pickers

<img width="1102" height="405" alt="image" src="https://github.com/user-attachments/assets/dd5b72b1-973e-4261-87de-b0e892af9468" />
