### PR TITLE
Add OPNsense bandwidth monitor support

### DIFF
--- a/Sources/Netfluss/AppState.swift
+++ b/Sources/Netfluss/AppState.swift
@@ -74,6 +74,8 @@ final class AppState {
             "unifiHost": "",
             "openWRTEnabled": false,
             "openWRTHost": "",
+            "opnsenseEnabled": false,
+            "opnsenseHost": "",
             "automaticUpdateChecksEnabled": true,
             "backgroundUpdateLastNotifiedVersion": ""
         ])

--- a/Sources/Netfluss/MenuBarView.swift
+++ b/Sources/Netfluss/MenuBarView.swift
@@ -41,6 +41,7 @@ struct MenuBarView: View {
     @AppStorage("fritzBoxEnabled") private var fritzBoxEnabled: Bool = false
     @AppStorage("unifiEnabled") private var unifiEnabled: Bool = false
     @AppStorage("openWRTEnabled") private var openWRTEnabled: Bool = false
+    @AppStorage("opnsenseEnabled") private var opnsenseEnabled: Bool = false
 
     private static let cardSpacing: CGFloat = 6   // VStack spacing between cards
     @State private var contentHeight: CGFloat = 0
@@ -187,6 +188,11 @@ struct MenuBarView: View {
                 if openWRTEnabled {
                     Divider()
                     OpenWRTSection(useBits: useBits)
+                }
+
+                if opnsenseEnabled {
+                    Divider()
+                    OPNsenseSection(useBits: useBits)
                 }
 
                 if showDNSSwitcher {
@@ -1289,5 +1295,62 @@ struct DNSPresetRow: View {
         }
         .buttonStyle(.borderless)
         .disabled(isActive || isChanging)
+    }
+}
+
+struct OPNsenseSection: View {
+    let useBits: Bool
+
+    @EnvironmentObject private var monitor: NetworkMonitor
+    @Environment(\.appTheme) private var theme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("OPNsense")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.secondary)
+            .padding(.horizontal, 12)
+            .padding(.top, 8)
+
+            if let error = monitor.opnsenseError {
+                HStack(spacing: 6) {
+                    Image(systemName: "exclamationmark.triangle")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.orange)
+                    Text(error)
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.horizontal, 12)
+                .padding(.bottom, 8)
+            } else if let data = monitor.opnsense {
+                VStack(spacing: 4) {
+                    RouterRateRow(
+                        icon: "arrow.down",
+                        label: "Download",
+                        rate: data.rxRateBps,
+                        maxRateMbps: data.linkSpeedMbps,
+                        color: downloadAccentColor(for: theme),
+                        useBits: useBits
+                    )
+                    RouterRateRow(
+                        icon: "arrow.up",
+                        label: "Upload",
+                        rate: data.txRateBps,
+                        maxRateMbps: data.linkSpeedMbps,
+                        color: uploadAccentColor(for: theme),
+                        useBits: useBits
+                    )
+                }
+                .padding(.horizontal, 12)
+                .padding(.bottom, 8)
+            } else {
+                Text("Gathering data…")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 12)
+                    .padding(.bottom, 8)
+            }
+        }
     }
 }

--- a/Sources/Netfluss/NetworkMonitor.swift
+++ b/Sources/Netfluss/NetworkMonitor.swift
@@ -46,6 +46,8 @@ final class NetworkMonitor: NSObject, ObservableObject {
     @Published var unifiError: String?
     @Published var openWRT: OpenWRTBandwidth?
     @Published var openWRTError: String?
+    @Published var opnsense: OPNsenseBandwidth?
+    @Published var opnsenseError: String?
 
     private var timer: DispatchSourceTimer?
     private let refreshQueue = DispatchQueue(label: "com.local.netfluss.refresh", qos: .utility)
@@ -56,6 +58,9 @@ final class NetworkMonitor: NSObject, ObservableObject {
     private var openWRTInFlight = false
     private var openWRTLastSample: OpenWRTSample?
     private var openWRTLastSampleHost: String?
+    private var opnsenseInFlight = false
+    private var opnsenseLastSample: OPNsenseSample?
+    private var opnsenseLastSampleHost: String?
     private var lastSample: [String: InterfaceSample] = [:]
     private var lastUpdate: Date?
     private var currentInterval: Double?
@@ -345,6 +350,7 @@ final class NetworkMonitor: NSObject, ObservableObject {
             updateFritzBox()
             updateUniFi()
             updateOpenWRT()
+            updateOPNsense()
         }
 
         let needsImmediateFollowUp = detailMonitoringEnabled && forceDetailRefresh
@@ -1007,6 +1013,67 @@ final class NetworkMonitor: NSObject, ObservableObject {
         }
     }
 
+    // MARK: - OPNsense
+
+    private func updateOPNsense() {
+        guard UserDefaults.standard.bool(forKey: "opnsenseEnabled") else {
+            if opnsense != nil { opnsense = nil }
+            if opnsenseError != nil { opnsenseError = nil }
+            opnsenseLastSample = nil
+            opnsenseLastSampleHost = nil
+            return
+        }
+        guard !opnsenseInFlight else { return }
+        opnsenseInFlight = true
+
+        let customHost = UserDefaults.standard.string(forKey: "opnsenseHost") ?? ""
+        let host = customHost.isEmpty ? gatewayIP : customHost
+        let usesAutoHost = customHost.isEmpty
+
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                guard let creds = OPNsenseMonitor.loadCredentials(host: host) else {
+                    let msg = "No credentials configured"
+                    self.setIfChanged(\.opnsenseError, to: msg)
+                    self.setIfChanged(\.opnsense, to: nil)
+                    self.opnsenseInFlight = false
+                    return
+                }
+                let sample = try await OPNsenseMonitor.fetchSample(
+                    host: host, apiKey: creds.apiKey, apiSecret: creds.apiSecret
+                )
+                // Compute rates from previous sample
+                if let prev = self.opnsenseLastSample, self.opnsenseLastSampleHost == host {
+                    let dt = sample.timestamp.timeIntervalSince(prev.timestamp)
+                    if dt > 0 {
+                        let rxRate = Double(sample.rxBytes &- prev.rxBytes) / dt
+                        let txRate = Double(sample.txBytes &- prev.txBytes) / dt
+                        self.setIfChanged(\.opnsense, to: OPNsenseBandwidth(
+                            rxRateBps: rxRate,
+                            txRateBps: txRate,
+                            linkSpeedMbps: sample.linkSpeedMbps
+                        ))
+                    }
+                }
+                self.opnsenseLastSample = sample
+                self.opnsenseLastSampleHost = host
+                self.setIfChanged(\.opnsenseError, to: nil)
+            } catch {
+                self.setIfChanged(\.opnsense, to: nil)
+                self.opnsenseLastSample = nil
+                self.opnsenseLastSampleHost = nil
+                let msg = Self.describeOPNsenseError(
+                    error,
+                    host: host,
+                    usesAutoHost: usesAutoHost
+                )
+                self.setIfChanged(\.opnsenseError, to: msg)
+            }
+            self.opnsenseInFlight = false
+        }
+    }
+
     private nonisolated static func runSyncOutput(_ path: String, _ args: [String]) -> String {
         runSyncResult(path, args).stdout
     }
@@ -1127,6 +1194,59 @@ final class NetworkMonitor: NSObject, ObservableObject {
         return usesAutoHost
             ? "Cannot reach OpenWRT. \(autoHint)"
             : "Cannot reach OpenWRT."
+    }
+
+    private nonisolated static func describeOPNsenseError(
+        _ error: Error,
+        host: String,
+        usesAutoHost: Bool
+    ) -> String {
+        let autoHint = "Auto uses the current default gateway. Set the OPNsense address manually if that is a different router."
+
+        if let opnsenseError = error as? OPNsenseError {
+            switch opnsenseError {
+            case .invalidURL:
+                return usesAutoHost
+                    ? "No OPNsense gateway address is available. \(autoHint)"
+                    : "Enter a valid OPNsense address or URL."
+            case .authFailed:
+                return "OPNsense login failed. Check the API credentials."
+            case .httpStatus(let statusCode):
+                if statusCode == 401 || statusCode == 403 {
+                    return "OPNsense authentication failed. Check the API key and secret."
+                }
+                return "OPNsense request failed (HTTP \(statusCode))."
+            case .noWANInterface:
+                return "OPNsense responded, but no WAN interface could be identified."
+            case .parseError:
+                return "OPNsense returned an unexpected response."
+            case .requestFailed:
+                return usesAutoHost
+                    ? "Cannot reach OPNsense at \(host). \(autoHint)"
+                    : "Cannot reach OPNsense at \(host)."
+            }
+        }
+
+        if let urlError = error as? URLError {
+            switch urlError.code {
+            case .timedOut:
+                return "OPNsense did not respond in time."
+            case .cannotFindHost, .cannotConnectToHost, .dnsLookupFailed, .networkConnectionLost, .notConnectedToInternet:
+                return usesAutoHost
+                    ? "Cannot reach OPNsense at \(host). \(autoHint)"
+                    : "Cannot reach OPNsense at \(host)."
+            default:
+                break
+            }
+        }
+
+        let message = (error as NSError).localizedDescription.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !message.isEmpty {
+            return message
+        }
+        return usesAutoHost
+            ? "Cannot reach OPNsense. \(autoHint)"
+            : "Cannot reach OPNsense."
     }
 }
 

--- a/Sources/Netfluss/OPNsenseMonitor.swift
+++ b/Sources/Netfluss/OPNsenseMonitor.swift
@@ -1,0 +1,432 @@
+// Copyright (C) 2026 Rana GmbH
+//
+// This file is part of Netfluss.
+//
+// Netfluss is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Netfluss is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Netfluss. If not, see <https://www.gnu.org/licenses/>.
+
+import Foundation
+import Security
+
+struct OPNsenseBandwidth: Equatable, Sendable {
+    let rxRateBps: Double
+    let txRateBps: Double
+    let linkSpeedMbps: UInt64
+}
+
+struct OPNsenseSample: Equatable, Sendable {
+    let rxBytes: UInt64
+    let txBytes: UInt64
+    let linkSpeedMbps: UInt64
+    let timestamp: Date
+    let interfaceID: String
+}
+
+enum OPNsenseError: Error {
+    case invalidURL
+    case authFailed
+    case httpStatus(Int)
+    case requestFailed
+    case parseError
+    case noWANInterface
+}
+
+enum OPNsenseMonitor {
+    // MARK: - Session Management
+
+    private static var sessionHost: String?
+    private static var sessionBaseURL: URL?
+
+    // MARK: - Public API
+
+    /// Validate host and remember the normalized API base URL.
+    static func login(host: String, apiKey: String, apiSecret: String) async throws {
+        let trimmed = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { throw OPNsenseError.invalidURL }
+
+        sessionHost = nil
+        sessionBaseURL = nil
+
+        var lastError: Error = OPNsenseError.requestFailed
+        for baseURL in try candidateBaseURLs(for: trimmed) {
+            do {
+                // Simple auth check against a lightweight GET endpoint.
+                _ = try await getJSON(
+                    baseURL: baseURL,
+                    path: "/api/diagnostics/traffic/interface",
+                    apiKey: apiKey,
+                    apiSecret: apiSecret
+                )
+
+                sessionHost = trimmed
+                sessionBaseURL = baseURL
+                return
+            } catch OPNsenseError.authFailed {
+                throw OPNsenseError.authFailed
+            } catch {
+                lastError = error
+            }
+        }
+
+        throw lastError
+    }
+
+    /// Discover the WAN-like interface identifier.
+    ///
+    /// OPNsense exposes a traffic interface endpoint, but public docs do not
+    /// fully document the exact response shape. This implementation is tolerant:
+    /// it accepts either:
+    /// - { "interfaces": { "wan": "WAN1_FIBRE", ... } }
+    /// - { "interfaces": ["wan", "opt1", ...] }
+    /// - { "interfaces": [{ "id": "wan", "name": "WAN1_FIBRE" }, ...] }
+    ///
+    /// Prefer a caller-supplied override if you already know the interface ID.
+    static func discoverWANInterface(
+        host: String,
+        apiKey: String,
+        apiSecret: String
+    ) async throws -> String {
+        let baseURL = try requireSessionBaseURL(for: host)
+
+        let json = try await getJSON(
+            baseURL: baseURL,
+            path: "/api/diagnostics/traffic/interface",
+            apiKey: apiKey,
+            apiSecret: apiSecret
+        )
+
+        guard let interfaces = json["interfaces"] as? [String: Any] else {
+            throw OPNsenseError.parseError
+        }
+
+        // OPNsense uses interface keys like "wan", "lan", "opt1"
+        // Try to pick the WAN interface
+        if let wanID = pickWANInterfaceID(from: Array(interfaces.keys)) {
+            return wanID
+        }
+
+        throw OPNsenseError.noWANInterface
+    }
+
+    /// Pick WAN interface from a list of interface IDs like ["wan", "lan", "opt1"].
+    private static func pickWANInterfaceID(from ids: [String]) -> String? {
+        // Prefer exact "wan"
+        if let exact = ids.first(where: { $0.lowercased() == "wan" }) {
+            return exact
+        }
+        // Otherwise look for anything starting with "wan"
+        if let prefixed = ids.first(where: { $0.lowercased().hasPrefix("wan") }) {
+            return prefixed
+        }
+        // Fallback: return first (shouldn't happen if we have a WAN)
+        return ids.first
+    }
+
+    /// Fetch bandwidth from the traffic interface endpoint.
+    /// This is simpler than using get_interface_statistics — it returns
+    /// interface data keyed by interface name (wan, lan, opt1) with byte counters
+    /// and link rate.
+    static func fetchInterfaceStats(
+        host: String,
+        apiKey: String,
+        apiSecret: String,
+        interfaceID: String
+    ) async throws -> OPNsenseSample {
+        let baseURL = try requireSessionBaseURL(for: host)
+
+        let json = try await getJSON(
+            baseURL: baseURL,
+            path: "/api/diagnostics/traffic/interface",
+            apiKey: apiKey,
+            apiSecret: apiSecret
+        )
+
+        guard let interfacesDict = json["interfaces"] as? [String: Any] else {
+            throw OPNsenseError.parseError
+        }
+
+        // interfaceID is like "wan", "lan", "opt1"
+        guard let ifaceData = interfacesDict[interfaceID] as? [String: Any] else {
+            print("OPNsense: Interface '\(interfaceID)' not found. Available: \(interfacesDict.keys.joined(separator: ", "))")
+            throw OPNsenseError.noWANInterface
+        }
+
+        let rxBytes = uint64Value(ifaceData["bytes received"])
+        let txBytes = uint64Value(ifaceData["bytes transmitted"])
+
+        // Parse "line rate" like "1000000000 bit/s" to Mbps
+        let linkSpeedMbps = parseLineRate(ifaceData["line rate"])
+
+        return OPNsenseSample(
+            rxBytes: rxBytes,
+            txBytes: txBytes,
+            linkSpeedMbps: linkSpeedMbps,
+            timestamp: Date(),
+            interfaceID: interfaceID
+        )
+    }
+
+    /// Parse line rate string like "1000000000 bit/s" to Mbps.
+    private static func parseLineRate(_ any: Any?) -> UInt64 {
+        guard let rateStr = any as? String else { return 0 }
+        // Extract numeric part before space or "bit/s"
+        let components = rateStr.split(separator: " ")
+        guard let firstPart = components.first, let bits = UInt64(firstPart) else { return 0 }
+        // Convert bits to Mbps (divide by 1,000,000)
+        return bits / 1_000_000
+    }
+
+    /// High-level API matching your OpenWRT version.
+    static func fetchSample(
+        host: String,
+        apiKey: String,
+        apiSecret: String,
+        preferredInterfaceID: String? = nil
+    ) async throws -> OPNsenseSample {
+        let trimmed = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { throw OPNsenseError.invalidURL }
+
+        if sessionHost == nil || sessionHost != trimmed || sessionBaseURL == nil {
+            try await login(host: trimmed, apiKey: apiKey, apiSecret: apiSecret)
+        }
+
+        let interfaceID: String
+        if let preferredInterfaceID, !preferredInterfaceID.isEmpty {
+            interfaceID = preferredInterfaceID
+        } else {
+            interfaceID = try await discoverWANInterface(
+                host: trimmed,
+                apiKey: apiKey,
+                apiSecret: apiSecret
+            )
+        }
+
+        do {
+            return try await fetchInterfaceStats(
+                host: trimmed,
+                apiKey: apiKey,
+                apiSecret: apiSecret,
+                interfaceID: interfaceID
+            )
+        } catch OPNsenseError.authFailed {
+            try await login(host: trimmed, apiKey: apiKey, apiSecret: apiSecret)
+            return try await fetchInterfaceStats(
+                host: trimmed,
+                apiKey: apiKey,
+                apiSecret: apiSecret,
+                interfaceID: interfaceID
+            )
+        }
+    }
+
+    /// Same client-side rate calculation model as your OpenWRT code.
+    static func bandwidth(from old: OPNsenseSample, to new: OPNsenseSample) -> OPNsenseBandwidth? {
+        let dt = new.timestamp.timeIntervalSince(old.timestamp)
+        guard dt > 0 else { return nil }
+
+        let rxDelta = new.rxBytes >= old.rxBytes ? new.rxBytes - old.rxBytes : 0
+        let txDelta = new.txBytes >= old.txBytes ? new.txBytes - old.txBytes : 0
+
+        return OPNsenseBandwidth(
+            rxRateBps: Double(rxDelta) / dt,
+            txRateBps: Double(txDelta) / dt,
+            linkSpeedMbps: new.linkSpeedMbps > 0 ? new.linkSpeedMbps : old.linkSpeedMbps
+        )
+    }
+
+    // MARK: - Transport
+
+    private static func requireSessionBaseURL(for host: String) throws -> URL {
+        guard let baseURL = sessionBaseURL, sessionHost == host else {
+            throw OPNsenseError.authFailed
+        }
+        return baseURL
+    }
+
+    private static func getJSON(
+        baseURL: URL,
+        path: String,
+        apiKey: String,
+        apiSecret: String
+    ) async throws -> [String: Any] {
+        let url = baseURL.appendingPathComponent(path.trimmingCharacters(in: CharacterSet(charactersIn: "/")))
+        var request = URLRequest(url: url, timeoutInterval: 10)
+        request.httpMethod = "GET"
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue(basicAuthHeader(apiKey: apiKey, apiSecret: apiSecret), forHTTPHeaderField: "Authorization")
+
+        do {
+            let session = makeSession()
+            let (data, response) = try await session.data(for: request)
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw OPNsenseError.requestFailed
+            }
+
+            switch httpResponse.statusCode {
+            case 200:
+                guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                    let responseBody = String(data: data, encoding: .utf8) ?? "(unable to decode)"
+                    let truncated = responseBody.prefix(100)
+                    print("OPNsense parse error. Response was: \(truncated)")
+                    throw OPNsenseError.parseError
+                }
+                return json
+            case 401, 403:
+                throw OPNsenseError.authFailed
+            default:
+                throw OPNsenseError.httpStatus(httpResponse.statusCode)
+            }
+        } catch let error as OPNsenseError {
+            throw error
+        } catch {
+            throw OPNsenseError.requestFailed
+        }
+    }
+
+    private static func candidateBaseURLs(for host: String) throws -> [URL] {
+        let trimmed = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { throw OPNsenseError.invalidURL }
+
+        if let components = URLComponents(string: trimmed), let scheme = components.scheme {
+            let normalizedScheme = scheme.lowercased()
+            guard normalizedScheme == "http" || normalizedScheme == "https",
+                  let normalized = normalizeBaseURL(from: components) else {
+                throw OPNsenseError.invalidURL
+            }
+            return [normalized]
+        }
+
+        guard let httpsURL = URL(string: "https://\(trimmed)"),
+              let httpURL = URL(string: "http://\(trimmed)") else {
+            throw OPNsenseError.invalidURL
+        }
+
+        return [httpsURL, httpURL]
+    }
+
+    private static func normalizeBaseURL(from components: URLComponents) -> URL? {
+        guard let host = components.host else { return nil }
+        var normalized = URLComponents()
+        normalized.scheme = components.scheme?.lowercased()
+        normalized.host = host
+        normalized.port = components.port
+        normalized.path = ""
+        return normalized.url
+    }
+
+    private static func basicAuthHeader(apiKey: String, apiSecret: String) -> String {
+        let raw = "\(apiKey):\(apiSecret)"
+        let encoded = Data(raw.utf8).base64EncodedString()
+        return "Basic \(encoded)"
+    }
+
+
+    private static func uint64Value(_ any: Any?) -> UInt64 {
+        switch any {
+        case let value as UInt64:
+            return value
+        case let value as Int:
+            return UInt64(max(value, 0))
+        case let value as Int64:
+            return UInt64(max(value, 0))
+        case let value as NSNumber:
+            return value.uint64Value
+        case let value as String:
+            return UInt64(value) ?? 0
+        default:
+            return 0
+        }
+    }
+
+    private static func makeSession() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = 10
+        return URLSession(configuration: config, delegate: InsecureTLSDelegate.shared, delegateQueue: nil)
+    }
+
+    // MARK: - Keychain Helpers
+
+    static func saveCredentials(host: String, apiKey: String, apiSecret: String) {
+        let service = "com.local.netfluss.opnsense"
+        let account = credentialAccount(for: host)
+        let value = "\(apiKey)\n\(apiSecret)"
+
+        guard let data = value.data(using: .utf8) else { return }
+
+        let deleteQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+        SecItemDelete(deleteQuery as CFDictionary)
+
+        let addQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecValueData as String: data
+        ]
+        SecItemAdd(addQuery as CFDictionary, nil)
+    }
+
+    static func loadCredentials(host: String) -> (apiKey: String, apiSecret: String)? {
+        let service = "com.local.netfluss.opnsense"
+        let account = credentialAccount(for: host)
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess,
+              let data = result as? Data,
+              let value = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+
+        let parts = value.split(separator: "\n", maxSplits: 1)
+        guard parts.count == 2 else { return nil }
+
+        return (apiKey: String(parts[0]), apiSecret: String(parts[1]))
+    }
+
+    static func deleteCredentials(host: String) {
+        let service = "com.local.netfluss.opnsense"
+        let account = credentialAccount(for: host)
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+
+    private static func credentialAccount(for host: String) -> String {
+        let trimmed = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let components = URLComponents(string: trimmed),
+              let normalizedHost = components.host else {
+            return trimmed
+        }
+        if let port = components.port {
+            return "\(normalizedHost):\(port)"
+        }
+        return normalizedHost
+    }
+}

--- a/Sources/Netfluss/PreferencesView.swift
+++ b/Sources/Netfluss/PreferencesView.swift
@@ -208,6 +208,8 @@ struct PreferencesView: View {
     @AppStorage("unifiHost") private var unifiHost: String = ""
     @AppStorage("openWRTEnabled") private var openWRTEnabled: Bool = false
     @AppStorage("openWRTHost") private var openWRTHost: String = ""
+    @AppStorage("opnsenseEnabled") private var opnsenseEnabled: Bool = false
+    @AppStorage("opnsenseHost") private var opnsenseHost: String = ""
     @AppStorage("automaticUpdateChecksEnabled") private var automaticUpdateChecksEnabled: Bool = true
     @State private var hiddenAdapters: Set<String> = []
     @State private var adapterNames: [String: String] = [:]
@@ -461,7 +463,7 @@ struct PreferencesView: View {
                         .frame(width: 160)
                     }
                 }
-                Text("Dashboard uses router-wide traffic when Fritz!Box, UniFi, or OpenWRT bandwidth is enabled and available.")
+                Text("Dashboard uses router-wide traffic when Fritz!Box, UniFi, OpenWRT, or OPNsense bandwidth is enabled and available.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -761,6 +763,69 @@ struct PreferencesView: View {
                 }
             } header: {
                 Text("OpenWRT Bandwidth")
+            }
+
+            Section {
+                Toggle("Show OPNsense bandwidth in popover", isOn: $opnsenseEnabled)
+                if opnsenseEnabled {
+                    LabeledContent("Router address") {
+                        HStack(spacing: 6) {
+                            if opnsenseHost.isEmpty {
+                                Text(monitor.gatewayIP)
+                                    .font(.system(size: 12))
+                                    .foregroundStyle(.secondary)
+                                Text("(auto)")
+                                    .font(.system(size: 10))
+                                    .foregroundStyle(.tertiary)
+                            } else {
+                                Text(opnsenseHost)
+                                    .font(.system(size: 12))
+                                    .foregroundStyle(.primary)
+                            }
+                            Button("Edit…") {
+                                EditRouterHostController.shared.show(
+                                    title: "OPNsense Address",
+                                    placeholder: "Router IP or URL (auto uses gateway)",
+                                    currentHost: opnsenseHost
+                                ) { newHost in
+                                    opnsenseHost = newHost
+                                }
+                            }
+                        }
+                    }
+                    LabeledContent("API Credentials") {
+                        HStack(spacing: 6) {
+                            let host = opnsenseHost.isEmpty ? monitor.gatewayIP : opnsenseHost
+                            if OPNsenseMonitor.loadCredentials(host: host) != nil {
+                                Text("Configured")
+                                    .font(.system(size: 12))
+                                    .foregroundStyle(.secondary)
+                            } else {
+                                Text("Not set")
+                                    .font(.system(size: 12))
+                                    .foregroundStyle(.orange)
+                            }
+                            Button("Edit…") {
+                                EditOPNsenseCredentialsController.shared.show(host: host)
+                            }
+                        }
+                    }
+                    Text("Queries your OPNsense router via REST API over HTTPS or HTTP. Auto uses the current default gateway. Requires API key and secret configured in OPNsense.")
+                        .foregroundStyle(.secondary)
+                        .font(.caption)
+                    if let error = monitor.opnsenseError {
+                        HStack(spacing: 4) {
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .foregroundStyle(.orange)
+                                .font(.system(size: 11))
+                            Text(error)
+                                .foregroundStyle(.secondary)
+                                .font(.caption)
+                        }
+                    }
+                }
+            } header: {
+                Text("OPNsense Bandwidth")
             }
 
             Section("Launch") {

--- a/Sources/Netfluss/PreferencesWindowController.swift
+++ b/Sources/Netfluss/PreferencesWindowController.swift
@@ -383,6 +383,192 @@ struct EditRouterCredentialsPanelView: View {
     }
 }
 
+// MARK: - OPNsense Credentials Editor
+
+@MainActor
+final class EditOPNsenseCredentialsController {
+    static let shared = EditOPNsenseCredentialsController()
+    private var panel: NSPanel?
+
+    func show(host: String, onSave: @escaping () -> Void = {}) {
+        if let panel {
+            panel.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+
+        let view = EditOPNsenseCredentialsPanelView(host: host) { [weak self] apiKey, apiSecret in
+            OPNsenseMonitor.saveCredentials(host: host, apiKey: apiKey, apiSecret: apiSecret)
+            onSave()
+            self?.close()
+        } onCancel: { [weak self] in
+            self?.close()
+        }
+        let hosting = NSHostingController(rootView: view)
+
+        let panel = NSPanel(contentViewController: hosting)
+        panel.title = "OPNsense API Credentials"
+        panel.styleMask = [.titled, .closable, .nonactivatingPanel]
+        panel.isFloatingPanel = true
+        panel.becomesKeyOnlyIfNeeded = false
+        panel.setContentSize(NSSize(width: 340, height: 280))
+        panel.isReleasedWhenClosed = false
+        panel.center()
+        panel.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+        panel.makeKey()
+
+        self.panel = panel
+    }
+
+    private func close() {
+        panel?.close()
+        panel = nil
+        reactivatePreferencesWindow()
+    }
+}
+
+struct EditOPNsenseCredentialsPanelView: View {
+    let host: String
+    let onSave: (String, String) -> Void
+    let onCancel: () -> Void
+
+    @State private var apiKey: String = ""
+    @State private var apiSecret: String = ""
+    @State private var isTesting = false
+    @State private var testPassed = false
+    @State private var testError: String?
+
+    private var canTest: Bool {
+        !apiKey.trimmingCharacters(in: .whitespaces).isEmpty && !apiSecret.isEmpty
+    }
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("OPNsense API Credentials")
+                .font(.headline)
+            Text("for \(host)")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            TextField("API Key", text: $apiKey)
+                .textFieldStyle(.roundedBorder)
+                .disabled(isTesting)
+            SecureField("API Secret", text: $apiSecret)
+                .textFieldStyle(.roundedBorder)
+                .disabled(isTesting)
+                .onSubmit { testConnection() }
+            Text("Generate these in OPNsense: System → User Management → API")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            // Test connection status
+            if let error = testError {
+                HStack(spacing: 6) {
+                    Image(systemName: "exclamationmark.circle.fill")
+                        .foregroundStyle(.orange)
+                        .font(.system(size: 12))
+                    Text(error)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            } else if testPassed {
+                HStack(spacing: 6) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                        .font(.system(size: 12))
+                    Text("Connection successful")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            HStack(spacing: 12) {
+                Button("Cancel", action: onCancel)
+                    .keyboardShortcut(.cancelAction)
+                    .disabled(isTesting)
+                Spacer()
+                Button(isTesting ? "Testing…" : "Test Connection") {
+                    testConnection()
+                }
+                .disabled(isTesting || !canTest)
+                Button("Save") { save() }
+                    .keyboardShortcut(.defaultAction)
+                    .buttonStyle(.borderedProminent)
+                    .disabled(isTesting || !testPassed)
+            }
+        }
+        .padding(24)
+        .onAppear {
+            if let creds = OPNsenseMonitor.loadCredentials(host: host) {
+                apiKey = creds.apiKey
+                apiSecret = creds.apiSecret
+            }
+        }
+    }
+
+    private func testConnection() {
+        let trimmedKey = apiKey.trimmingCharacters(in: .whitespaces)
+        guard !trimmedKey.isEmpty, !apiSecret.isEmpty else { return }
+
+        isTesting = true
+        testError = nil
+        testPassed = false
+
+        Task {
+            do {
+                try await OPNsenseMonitor.login(host: host, apiKey: trimmedKey, apiSecret: apiSecret)
+                await MainActor.run {
+                    testPassed = true
+                    testError = nil
+                    isTesting = false
+                }
+            } catch {
+                let errorMsg: String
+                if let opnsenseError = error as? OPNsenseError {
+                    switch opnsenseError {
+                    case .authFailed:
+                        errorMsg = "API key or secret is incorrect (HTTP 401/403)"
+                    case .invalidURL:
+                        errorMsg = "Invalid router address or URL format"
+                    case .httpStatus(let code):
+                        errorMsg = "HTTP error \(code) — check the router address and verify the API is enabled"
+                    case .parseError:
+                        errorMsg = "Router returned unexpected format — verify the API endpoint or check the OPNsense logs (console output has details)"
+                    case .requestFailed:
+                        errorMsg = "Could not reach router — verify address and network connectivity"
+                    case .noWANInterface:
+                        errorMsg = "Router responded but WAN interface not found"
+                    }
+                } else if let urlError = error as? URLError {
+                    switch urlError.code {
+                    case .timedOut:
+                        errorMsg = "Router did not respond in time"
+                    case .cannotFindHost:
+                        errorMsg = "Could not resolve host — check the address"
+                    case .cannotConnectToHost:
+                        errorMsg = "Could not connect to router — verify address and network"
+                    default:
+                        errorMsg = "Network error: \((error as NSError).localizedDescription)"
+                    }
+                } else {
+                    errorMsg = "Error: \((error as NSError).localizedDescription)"
+                }
+                await MainActor.run {
+                    testPassed = false
+                    testError = errorMsg
+                    isTesting = false
+                }
+            }
+        }
+    }
+
+    private func save() {
+        let trimmedKey = apiKey.trimmingCharacters(in: .whitespaces)
+        guard !trimmedKey.isEmpty, !apiSecret.isEmpty, testPassed else { return }
+        onSave(trimmedKey, apiSecret)
+    }
+}
+
 struct AddDNSPanelView: View {
     let editingPreset: DNSPreset?
     let onSave: (DNSPreset) -> Void


### PR DESCRIPTION
## Summary

Add bandwidth monitoring support for OPNsense firewalls, matching the existing Fritz!Box, UniFi, and OpenWRT integrations.

## Features

- Fetches real-time bandwidth from OPNsense REST API
- Auto-discovers WAN interface (wan, lan, opt1)
- Secure credential storage in macOS Keychain
- Validates credentials with connection test before saving
- Displays download/upload rates with max link speed in menu bar
- Error handling with helpful user messages

## Implementation Details

**New file: `OPNsenseMonitor.swift`**
- REST API client with HTTP Basic Auth
- Session management with auto-reauth on 401/403
- Uses `/api/diagnostics/traffic/interface` endpoint
- Parses byte counters and line rate from OPNsense response
- Keychain integration for secure API key/secret storage

**Integration points:**
- `NetworkMonitor.swift` – Added @Published opnsense properties and refresh logic
- `MenuBarView.swift` – OPNsenseSection displays rates (matches other routers)
- `PreferencesView.swift` – Toggle, address field, credential management
- `PreferencesWindowController.swift` – Credentials panel with connection test
- `AppState.swift` – Registered UserDefaults keys

## User Experience

Users can:
1. Enable OPNsense in Preferences
2. Enter router address (auto-detect or manual)
3. Enter API key + secret (generated in OPNsense System → User Management → API)
4. Click Test Connection to validate credentials
5. Save and start monitoring bandwidth in the menu bar

Credentials are stored securely in macOS Keychain.