### PR TITLE
Add System default menu bar color that adapts to appearance

### DIFF
--- a/Sources/Netfluss/PreferencesView.swift
+++ b/Sources/Netfluss/PreferencesView.swift
@@ -20,6 +20,7 @@ import ServiceManagement
 import SwiftUI
 
 private let colorOptions: [(id: String, label: String)] = [
+    ("system", "System default"),
     ("green", "Green"), ("blue", "Blue"), ("orange", "Orange"),
     ("teal", "Teal"), ("purple", "Purple"), ("pink", "Pink"), ("white", "White"), ("black", "Black")
 ]
@@ -37,6 +38,7 @@ private func swatchColor(_ name: String) -> Color {
     case "pink":   return .pink
     case "white":  return Color(.white)
     case "black":  return Color(.black)
+    case "system": return Color(nsColor: .labelColor)
     default:       return .primary
     }
 }

--- a/Sources/Netfluss/StatusBarController.swift
+++ b/Sources/Netfluss/StatusBarController.swift
@@ -954,22 +954,22 @@ final class StatusBarController: NSObject, NSPopoverDelegate, NSMenuDelegate {
         let menuBarDownloadTextColorName = UserDefaults.standard.string(forKey: "menuBarDownloadTextColor") ?? "blue"
         let menuBarUploadTextColorHex = UserDefaults.standard.string(forKey: "menuBarUploadTextColorHex") ?? ""
         let menuBarDownloadTextColorHex = UserDefaults.standard.string(forKey: "menuBarDownloadTextColorHex") ?? ""
-        let upColor = resolvedAccentNSColor(
+        var upColor = resolvedAccentNSColor(
             selection: uploadColorName,
             customHex: uploadColorHex,
             fallback: NSColor(theme.uploadColor)
         )
-        let downColor = resolvedAccentNSColor(
+        var downColor = resolvedAccentNSColor(
             selection: downloadColorName,
             customHex: downloadColorHex,
             fallback: NSColor(theme.downloadColor)
         )
-        let upTextColor = resolvedAccentNSColor(
+        var upTextColor = resolvedAccentNSColor(
             selection: menuBarUploadTextColorName,
             customHex: menuBarUploadTextColorHex,
             fallback: upColor
         )
-        let downTextColor = resolvedAccentNSColor(
+        var downTextColor = resolvedAccentNSColor(
             selection: menuBarDownloadTextColorName,
             customHex: menuBarDownloadTextColorHex,
             fallback: downColor
@@ -982,6 +982,20 @@ final class StatusBarController: NSObject, NSPopoverDelegate, NSMenuDelegate {
         case .stack, .unified:
             defaultTextColor = .labelColor
         }
+
+        // "System default" resolves to NSColor.labelColor, which is near-black on a
+        // light appearance. Dashboard styles draw a fixed dark capsule, so labelColor
+        // would be invisible there — substitute the dashboard text color instead.
+        switch style {
+        case .dashboard, .dashboardBasic:
+            if uploadColorName == "system" { upColor = defaultTextColor }
+            if downloadColorName == "system" { downColor = defaultTextColor }
+            if menuBarUploadTextColorName == "system" { upTextColor = defaultTextColor }
+            if menuBarDownloadTextColorName == "system" { downTextColor = defaultTextColor }
+        case .stack, .unified:
+            break
+        }
+
         let textColor = defaultTextColor
         let secondaryTextColor: NSColor = {
             switch style {

--- a/Sources/Netfluss/Themes.swift
+++ b/Sources/Netfluss/Themes.swift
@@ -101,6 +101,7 @@ private func accentNSColor(named name: String) -> NSColor? {
     case "pink":   return .systemPink
     case "white":  return .white
     case "black":  return .black
+    case "system": return .labelColor
     default:       return nil
     }
 }


### PR DESCRIPTION
## What

Adds a **System default** option to the menu bar color pickers (download/upload arrows and menu bar text). When selected, the menu bar text and arrows render with the dynamic system color `NSColor.labelColor`, which automatically adapts to the active menu bar appearance, so the text stays legible when the wallpaper or menu bar appearance switches between light and dark, with no manual re-adjustment.

## Why

Closes #46. Today the menu bar appearance has to be set to an explicit color, which is not compatible with the macOS default menu bar color: after switching to a light wallpaper the text can become hard to read and has to be re-adjusted by hand. A "use the system default" choice that follows the menu bar appearance removes that manual step.

## How

The color selection already flows through a single resolver, so the change is small:

- `Themes.swift`: `accentNSColor(named:)` now returns `NSColor.labelColor` for the new `"system"` selection. Because both the arrow colors and the menu bar text colors resolve through `resolvedAccentNSColor(...)`, the new option works for all of them without touching the resolution call sites. Unknown/empty selections still fall back to the existing color (the `default: return nil` path is unchanged), so nothing renders invisible.
- `PreferencesView.swift`: adds `("system", "System default")` as the first swatch in `colorOptions` and a matching `swatchColor` case so the swatch preview shows the dynamic label color.
- `StatusBarController.swift`: the **Dashboard** and **Dashboard (basic)** menu bar styles draw a fixed dark capsule background, where a near-black `labelColor` (light appearance) would be invisible. For those two styles only, a `"system"` selection is mapped to the dashboard text color instead; the `stack`/`unified` styles are unchanged.

Existing users who previously picked an explicit color keep their selection. The per-picker default selection strings are unchanged, so this is purely additive.

## Testing

- `swift build -c release --arch arm64` builds cleanly.
- With **System default** selected, the menu bar text and arrows render legibly in the `stack` and `unified` styles on both light and dark menu bar appearances, and the dashboard styles keep their high-contrast text.
- Switching between an explicit color, custom hex, and System default updates the rendered color and persists in `UserDefaults` like the existing color keys.

Note: I saw the issue carries an "In Progress" label and your note that you'd look into this yourself, so please treat this as a candidate demonstration of the system-default approach. Happy to adjust the UI wording or the dashboard handling, or close it if you already have an approach in flight.
