### PR TITLE
Add Data Usage summary with localization and enhanced statistics

### DIFF
--- a/Packaging/Resources/de.lproj/Localizable.strings
+++ b/Packaging/Resources/de.lproj/Localizable.strings
@@ -208,6 +208,12 @@
 "Hourly Traffic" = "Stündlicher Datenverkehr";
 "Daily Traffic" = "Täglicher Datenverkehr";
 "Monthly Traffic" = "Monatlicher Datenverkehr";
+"Data Usage" = "Datennutzung";
+"Today" = "Heute";
+"This Month" = "Dieser Monat";
+"Total" = "Gesamt";
+"Display usage summary on popover" = "Nutzungsübersicht im Popover anzeigen";
+"Shows today's and this month's upload, download, and total data in the popover. Requires historical statistics collection." = "Zeigt Upload, Download und Gesamtvolumen für heute und diesen Monat im Popover an. Erfordert die Erfassung historischer Statistiken.";
 "Run Test" = "Test starten";
 "Run Again" = "Erneut starten";
 "Connection Details" = "Verbindungsdetails";

--- a/Packaging/Resources/en.lproj/Localizable.strings
+++ b/Packaging/Resources/en.lproj/Localizable.strings
@@ -208,6 +208,12 @@
 "Hourly Traffic" = "Hourly Traffic";
 "Daily Traffic" = "Daily Traffic";
 "Monthly Traffic" = "Monthly Traffic";
+"Data Usage" = "Data Usage";
+"Today" = "Today";
+"This Month" = "This Month";
+"Total" = "Total";
+"Display usage summary on popover" = "Display usage summary on popover";
+"Shows today's and this month's upload, download, and total data in the popover. Requires historical statistics collection." = "Shows today's and this month's upload, download, and total data in the popover. Requires historical statistics collection.";
 "Run Test" = "Run Test";
 "Run Again" = "Run Again";
 "Connection Details" = "Connection Details";

--- a/Packaging/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Packaging/Resources/zh-Hans.lproj/Localizable.strings
@@ -208,6 +208,12 @@
 "Hourly Traffic" = "小时流量";
 "Daily Traffic" = "每日流量";
 "Monthly Traffic" = "每月流量";
+"Data Usage" = "数据用量";
+"Today" = "今天";
+"This Month" = "本月";
+"Total" = "总计";
+"Display usage summary on popover" = "在弹出窗口中显示用量摘要";
+"Shows today's and this month's upload, download, and total data in the popover. Requires historical statistics collection." = "在弹出窗口中显示今天和本月的上传、下载和总数据量。需要开启历史统计收集。";
 "Run Test" = "运行测试";
 "Run Again" = "再次运行";
 "Connection Details" = "连接详情";

--- a/Packaging/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Packaging/Resources/zh-Hant.lproj/Localizable.strings
@@ -208,6 +208,12 @@
 "Hourly Traffic" = "小時流量";
 "Daily Traffic" = "每日流量";
 "Monthly Traffic" = "每月流量";
+"Data Usage" = "數據用量";
+"Today" = "今天";
+"This Month" = "本月";
+"Total" = "總計";
+"Display usage summary on popover" = "在彈出視窗中顯示用量摘要";
+"Shows today's and this month's upload, download, and total data in the popover. Requires historical statistics collection." = "在彈出視窗中顯示今天和本月的上傳、下載和總數據量。需要開啟歷史統計收集。";
 "Run Test" = "執行測試";
 "Run Again" = "再次執行";
 "Connection Details" = "連線詳細資訊";

--- a/Sources/Netfluss/AppState.swift
+++ b/Sources/Netfluss/AppState.swift
@@ -72,6 +72,7 @@ final class AppState {
             "wifiLimitCount": 10,
             "showTotalsHeader": true,
             "showAdapterList": true,
+            "showUsageSummary": false,
             "popoverSectionOrder": PopoverSection.defaultOrder.map(\.rawValue),
             "lastConnectionStatusMode": "flow",
             "customDNSPresets": Data(),

--- a/Sources/Netfluss/MenuBarView.swift
+++ b/Sources/Netfluss/MenuBarView.swift
@@ -25,6 +25,7 @@ struct MenuBarView: View {
     let onTogglePin: () -> Void
 
     @EnvironmentObject private var monitor: NetworkMonitor
+    @EnvironmentObject private var statisticsManager: StatisticsManager
     @AppStorage("showInactive") private var showInactive: Bool = false
     @AppStorage("adapterGracePeriodEnabled") private var adapterGracePeriodEnabled: Bool = false
     @AppStorage("showOtherAdapters") private var showOtherAdapters: Bool = false
@@ -46,6 +47,8 @@ struct MenuBarView: View {
     @AppStorage("opnsenseEnabled") private var opnsenseEnabled: Bool = false
     @AppStorage("showTotalsHeader") private var showTotalsHeader: Bool = true
     @AppStorage("showAdapterList") private var showAdapterList: Bool = true
+    @AppStorage("showUsageSummary") private var showUsageSummary: Bool = false
+    @AppStorage("collectStatistics") private var collectStatistics: Bool = false
 
     private static let cardSpacing: CGFloat = 6   // VStack spacing between cards
     @State private var contentHeight: CGFloat = 0
@@ -144,6 +147,7 @@ struct MenuBarView: View {
     private func isSectionVisible(_ section: PopoverSection) -> Bool {
         switch section {
         case .totals: return showTotalsHeader
+        case .usage: return showUsageSummary && collectStatistics
         case .adapters: return showAdapterList
         case .connection: return connectionStatusMode != "none"
         case .dns: return showDNSSwitcher
@@ -165,6 +169,9 @@ struct MenuBarView: View {
         switch section {
         case .totals:
             TotalRatesHeader(totals: headerTotals, useBits: useBits)
+
+        case .usage:
+            UsageSummarySection()
 
         case .adapters:
             if adapters.isEmpty {

--- a/Sources/Netfluss/Models.swift
+++ b/Sources/Netfluss/Models.swift
@@ -198,6 +198,7 @@ struct WifiNetwork: Identifiable, Equatable, Sendable {
 /// canonical visibility keys (see PopoverSection.visibilityKey).
 enum PopoverSection: String, CaseIterable, Identifiable, Sendable {
     case totals
+    case usage
     case adapters
     case connection
     case dns
@@ -209,12 +210,13 @@ enum PopoverSection: String, CaseIterable, Identifiable, Sendable {
     var id: String { rawValue }
 
     static let defaultOrder: [PopoverSection] = [
-        .totals, .adapters, .connection, .dns, .router, .wifi, .vpn, .topApps
+        .totals, .adapters, .connection, .dns, .router, .wifi, .vpn, .topApps, .usage
     ]
 
     var displayName: String {
         switch self {
         case .totals: return "Download / Upload"
+        case .usage: return "Data Usage"
         case .adapters: return "Network adapters"
         case .connection: return "Network flow"
         case .dns: return "DNS"
@@ -228,6 +230,7 @@ enum PopoverSection: String, CaseIterable, Identifiable, Sendable {
     var systemImage: String {
         switch self {
         case .totals: return "arrow.up.arrow.down"
+        case .usage: return "chart.bar.doc.horizontal"
         case .adapters: return "network"
         case .connection: return "globe"
         case .dns: return "server.rack"

--- a/Sources/Netfluss/PreferencesView.swift
+++ b/Sources/Netfluss/PreferencesView.swift
@@ -262,6 +262,7 @@ struct PreferencesView: View {
     @AppStorage("topAppsGracePeriodSeconds") private var topAppsGracePeriodSeconds: Double = 3.0
     @AppStorage("collectStatistics") private var collectStatistics: Bool = false
     @AppStorage("collectAppStatistics") private var collectAppStatistics: Bool = true
+    @AppStorage("showUsageSummary") private var showUsageSummary: Bool = false
     @AppStorage("externalIPv6") private var externalIPv6: Bool = false
     @AppStorage("showDNSSwitcher") private var showDNSSwitcher: Bool = false
     @AppStorage("showWifiSwitcher") private var showWifiSwitcher: Bool = false
@@ -485,6 +486,14 @@ struct PreferencesView: View {
                     LText("Collect historical statistics")
                 }
                 LText("Disabled by default to avoid extra background work and energy use. When enabled, NetFluss keeps hourly and daily rollups for adapters and optional app traffic analysis.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Toggle(isOn: $showUsageSummary) {
+                    LText("Display usage summary on popover")
+                }
+                .disabled(!collectStatistics)
+                LText("Shows today's and this month's upload, download, and total data in the popover. Requires historical statistics collection.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
@@ -1441,6 +1450,8 @@ private struct PopoverSectionsReorderEditor: View {
     @AppStorage("showWifiSwitcher") private var showWifiSwitcher: Bool = false
     @AppStorage("showVPN") private var showVPN: Bool = false
     @AppStorage("showTopApps") private var showTopApps: Bool = false
+    @AppStorage("showUsageSummary") private var showUsageSummary: Bool = false
+    @AppStorage("collectStatistics") private var collectStatistics: Bool = false
     @AppStorage("fritzBoxEnabled") private var fritzBoxEnabled: Bool = false
     @AppStorage("unifiEnabled") private var unifiEnabled: Bool = false
     @AppStorage("openWRTEnabled") private var openWRTEnabled: Bool = false
@@ -1458,6 +1469,8 @@ private struct PopoverSectionsReorderEditor: View {
         switch section {
         case .totals:
             return Binding(get: { showTotalsHeader }, set: { showTotalsHeader = $0 })
+        case .usage:
+            return Binding(get: { showUsageSummary }, set: { showUsageSummary = $0 })
         case .adapters:
             return Binding(get: { showAdapterList }, set: { showAdapterList = $0 })
         case .connection:
@@ -1504,7 +1517,7 @@ private struct PopoverSectionsReorderEditor: View {
     private func toggleDisabled(_ section: PopoverSection) -> Bool {
         // Router toggle can only be turned OFF from here (turning on requires
         // configuring an individual router in the Router pane).
-        section == .router && !anyRouterEnabled
+        (section == .router && !anyRouterEnabled) || (section == .usage && !collectStatistics)
     }
 
     var body: some View {

--- a/Sources/Netfluss/Resources/de.lproj/Localizable.strings
+++ b/Sources/Netfluss/Resources/de.lproj/Localizable.strings
@@ -208,6 +208,12 @@
 "Hourly Traffic" = "Stündlicher Datenverkehr";
 "Daily Traffic" = "Täglicher Datenverkehr";
 "Monthly Traffic" = "Monatlicher Datenverkehr";
+"Data Usage" = "Datennutzung";
+"Today" = "Heute";
+"This Month" = "Dieser Monat";
+"Total" = "Gesamt";
+"Display usage summary on popover" = "Nutzungsübersicht im Popover anzeigen";
+"Shows today's and this month's upload, download, and total data in the popover. Requires historical statistics collection." = "Zeigt Upload, Download und Gesamtvolumen für heute und diesen Monat im Popover an. Erfordert die Erfassung historischer Statistiken.";
 "Run Test" = "Test starten";
 "Run Again" = "Erneut starten";
 "Connection Details" = "Verbindungsdetails";

--- a/Sources/Netfluss/Resources/en.lproj/Localizable.strings
+++ b/Sources/Netfluss/Resources/en.lproj/Localizable.strings
@@ -208,6 +208,12 @@
 "Hourly Traffic" = "Hourly Traffic";
 "Daily Traffic" = "Daily Traffic";
 "Monthly Traffic" = "Monthly Traffic";
+"Data Usage" = "Data Usage";
+"Today" = "Today";
+"This Month" = "This Month";
+"Total" = "Total";
+"Display usage summary on popover" = "Display usage summary on popover";
+"Shows today's and this month's upload, download, and total data in the popover. Requires historical statistics collection." = "Shows today's and this month's upload, download, and total data in the popover. Requires historical statistics collection.";
 "Run Test" = "Run Test";
 "Run Again" = "Run Again";
 "Connection Details" = "Connection Details";

--- a/Sources/Netfluss/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Netfluss/Resources/zh-Hans.lproj/Localizable.strings
@@ -208,6 +208,12 @@
 "Hourly Traffic" = "小时流量";
 "Daily Traffic" = "每日流量";
 "Monthly Traffic" = "每月流量";
+"Data Usage" = "数据用量";
+"Today" = "今天";
+"This Month" = "本月";
+"Total" = "总计";
+"Display usage summary on popover" = "在弹出窗口中显示用量摘要";
+"Shows today's and this month's upload, download, and total data in the popover. Requires historical statistics collection." = "在弹出窗口中显示今天和本月的上传、下载和总数据量。需要开启历史统计收集。";
 "Run Test" = "运行测试";
 "Run Again" = "再次运行";
 "Connection Details" = "连接详情";

--- a/Sources/Netfluss/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Netfluss/Resources/zh-Hant.lproj/Localizable.strings
@@ -208,6 +208,12 @@
 "Hourly Traffic" = "小時流量";
 "Daily Traffic" = "每日流量";
 "Monthly Traffic" = "每月流量";
+"Data Usage" = "數據用量";
+"Today" = "今天";
+"This Month" = "本月";
+"Total" = "總計";
+"Display usage summary on popover" = "在彈出視窗中顯示用量摘要";
+"Shows today's and this month's upload, download, and total data in the popover. Requires historical statistics collection." = "在彈出視窗中顯示今天和本月的上傳、下載和總數據量。需要開啟歷史統計收集。";
 "Run Test" = "執行測試";
 "Run Again" = "再次執行";
 "Connection Details" = "連線詳細資訊";

--- a/Sources/Netfluss/StatisticsManager.swift
+++ b/Sources/Netfluss/StatisticsManager.swift
@@ -34,6 +34,7 @@ final class StatisticsManager: ObservableObject {
     @Published private(set) var report: StatisticsReport?
     @Published private(set) var isLoading = false
     @Published private(set) var isShowingSampleData = false
+    @Published private(set) var usageSummary: StatisticsUsageSummary = .empty
 
     private let monitor: NetworkMonitor
     private let store: StatisticsStore
@@ -81,6 +82,7 @@ final class StatisticsManager: ObservableObject {
 
         if !statisticsEnabled {
             previousAdapterSnapshot = snapshotMap(from: monitor.adapters)
+            usageSummary = .empty
         }
         if !appStatisticsEnabled {
             previousAppSnapshot = [:]
@@ -144,6 +146,22 @@ final class StatisticsManager: ObservableObject {
         }
     }
 
+    /// Recompute the popover "Data Usage" summary on demand (e.g. when the
+    /// section appears) so it is current even after an idle stretch with no new
+    /// adapter deltas. Resets to empty when collection is off.
+    func refreshUsageSummary() {
+        guard statisticsEnabled else {
+            usageSummary = .empty
+            return
+        }
+        Task { [store] in
+            let summary = await store.usageSummary(now: Date())
+            await MainActor.run {
+                self.usageSummary = summary
+            }
+        }
+    }
+
     func enableSampleData() {
         sampleStore = StatisticsStore(archive: StatisticsDemoData.makeArchive(now: Date()))
         isShowingSampleData = true
@@ -174,6 +192,12 @@ final class StatisticsManager: ObservableObject {
         statisticsEnabled && UserDefaults.standard.bool(forKey: "collectAppStatistics")
     }
 
+    /// True only when history collection is on AND the popover section is
+    /// enabled. Gates the per-tick summary recompute so a hidden section is free.
+    private var usageSummaryEnabled: Bool {
+        statisticsEnabled && UserDefaults.standard.bool(forKey: "showUsageSummary")
+    }
+
     private func ingestAdapterSnapshot(_ adapters: [AdapterStatus]) {
         let currentSnapshot = snapshotMap(from: adapters)
         guard statisticsEnabled else {
@@ -202,8 +226,16 @@ final class StatisticsManager: ObservableObject {
         bytesSinceLastAppSample &+= deltas.reduce(UInt64(0)) { $0 &+ $1.downloadBytes &+ $1.uploadBytes }
         guard !deltas.isEmpty else { return }
 
-        Task.detached(priority: .utility) { [store] in
-            await store.recordAdapterDeltas(deltas, at: Date())
+        // Keep the popover's "Data Usage" summary live while that section is on.
+        // Recomputed in the same task right after recording so it reflects these
+        // deltas; gated on `usageSummaryEnabled` so a hidden section costs nothing.
+        let refreshSummary = usageSummaryEnabled
+        Task.detached(priority: .utility) { [store, weak self] in
+            let sampleDate = Date()
+            await store.recordAdapterDeltas(deltas, at: sampleDate)
+            guard refreshSummary else { return }
+            let summary = await store.usageSummary(now: sampleDate)
+            await MainActor.run { [weak self] in self?.usageSummary = summary }
         }
     }
 

--- a/Sources/Netfluss/StatisticsManager.swift
+++ b/Sources/Netfluss/StatisticsManager.swift
@@ -88,6 +88,10 @@ final class StatisticsManager: ObservableObject {
             previousAppSnapshot = [:]
             previousAppSampleTime = nil
         }
+
+        if usageSummaryLive {
+            refreshUsageSummary()
+        }
     }
 
     func loadReport(for range: StatisticsRange) {
@@ -99,13 +103,15 @@ final class StatisticsManager: ObservableObject {
         let customAdapterNames = Self.loadAdapterNames()
         let hiddenApps = Set(UserDefaults.standard.stringArray(forKey: "hiddenApps") ?? [])
         let activeStore = isShowingSampleData ? (sampleStore ?? store) : store
+        let excludeTunnels = excludeTunnelsFromTotals
 
         Task { [activeStore] in
             let report = await activeStore.report(
                 for: range,
                 now: Date(),
                 customAdapterNames: customAdapterNames,
-                hiddenApps: hiddenApps
+                hiddenApps: hiddenApps,
+                excludeTunnels: excludeTunnels
             )
             await MainActor.run {
                 self.report = report
@@ -122,6 +128,7 @@ final class StatisticsManager: ObservableObject {
         let customAdapterNames = Self.loadAdapterNames()
         let hiddenApps = Set(UserDefaults.standard.stringArray(forKey: "hiddenApps") ?? [])
         let activeStore = isShowingSampleData ? (sampleStore ?? store) : store
+        let excludeTunnels = excludeTunnelsFromTotals
 
         Task { [activeStore] in
             let report = await activeStore.report(
@@ -129,7 +136,8 @@ final class StatisticsManager: ObservableObject {
                 customEnd: customEnd,
                 now: Date(),
                 customAdapterNames: customAdapterNames,
-                hiddenApps: hiddenApps
+                hiddenApps: hiddenApps,
+                excludeTunnels: excludeTunnels
             )
             await MainActor.run {
                 self.report = report
@@ -146,17 +154,21 @@ final class StatisticsManager: ObservableObject {
         }
     }
 
-    /// Recompute the popover "Data Usage" summary on demand (e.g. when the
-    /// section appears) so it is current even after an idle stretch with no new
-    /// adapter deltas. Resets to empty when collection is off.
+    /// Recompute the popover "Data Usage" summary from the live store (never the
+    /// sample-data preview). Token-guarded so an older async result can't clobber a
+    /// newer one. Resets to empty when collection is off.
     func refreshUsageSummary() {
         guard statisticsEnabled else {
             usageSummary = .empty
             return
         }
-        Task { [store] in
-            let summary = await store.usageSummary(now: Date())
+        usageSummaryToken &+= 1
+        let token = usageSummaryToken
+        let excludeTunnels = excludeTunnelsFromTotals
+        Task { [store, weak self] in
+            let summary = await store.usageSummary(now: Date(), excludeTunnels: excludeTunnels)
             await MainActor.run {
+                guard let self, token == self.usageSummaryToken else { return }
                 self.usageSummary = summary
             }
         }
@@ -192,10 +204,32 @@ final class StatisticsManager: ObservableObject {
         statisticsEnabled && UserDefaults.standard.bool(forKey: "collectAppStatistics")
     }
 
-    /// True only when history collection is on AND the popover section is
-    /// enabled. Gates the per-tick summary recompute so a hidden section is free.
-    private var usageSummaryEnabled: Bool {
-        statisticsEnabled && UserDefaults.standard.bool(forKey: "showUsageSummary")
+    /// Whether the popover section is currently on screen (popover shown or
+    /// pinned window visible). Set from `StatusBarController.updateDetailMonitoring`.
+    private var liveSummaryActive = false
+
+    /// Monotonic token so a slow async recompute can't overwrite a newer summary.
+    private var usageSummaryToken = 0
+
+    /// True only while the Data Usage section is on screen AND history collection
+    /// is on AND the section is enabled — gates the per-tick recompute so a hidden
+    /// or closed section costs nothing.
+    private var usageSummaryLive: Bool {
+        liveSummaryActive && statisticsEnabled && UserDefaults.standard.bool(forKey: "showUsageSummary")
+    }
+
+    /// Whether tunnel/VPN adapters are excluded from totals — mirrors the live
+    /// Download/Upload totals so the popover's figures agree.
+    private var excludeTunnelsFromTotals: Bool {
+        UserDefaults.standard.bool(forKey: "excludeTunnelAdaptersFromTotals")
+    }
+
+    /// Called when the popover / pinned window becomes visible or hidden. On
+    /// becoming visible, refresh immediately so the numbers are current.
+    func setLiveSummaryActive(_ active: Bool) {
+        guard active != liveSummaryActive else { return }
+        liveSummaryActive = active
+        if active { refreshUsageSummary() }
     }
 
     private func ingestAdapterSnapshot(_ adapters: [AdapterStatus]) {
@@ -226,16 +260,13 @@ final class StatisticsManager: ObservableObject {
         bytesSinceLastAppSample &+= deltas.reduce(UInt64(0)) { $0 &+ $1.downloadBytes &+ $1.uploadBytes }
         guard !deltas.isEmpty else { return }
 
-        // Keep the popover's "Data Usage" summary live while that section is on.
-        // Recomputed in the same task right after recording so it reflects these
-        // deltas; gated on `usageSummaryEnabled` so a hidden section costs nothing.
-        let refreshSummary = usageSummaryEnabled
-        Task.detached(priority: .utility) { [store, weak self] in
-            let sampleDate = Date()
-            await store.recordAdapterDeltas(deltas, at: sampleDate)
-            guard refreshSummary else { return }
-            let summary = await store.usageSummary(now: sampleDate)
-            await MainActor.run { [weak self] in self?.usageSummary = summary }
+        // History collection runs continuously regardless of visibility; the
+        // on-screen Data Usage summary is refreshed separately (visibility-gated).
+        Task.detached(priority: .utility) { [store] in
+            await store.recordAdapterDeltas(deltas, at: Date())
+        }
+        if usageSummaryLive {
+            refreshUsageSummary()
         }
     }
 

--- a/Sources/Netfluss/StatisticsModels.swift
+++ b/Sources/Netfluss/StatisticsModels.swift
@@ -33,6 +33,15 @@ struct StatisticsTrafficAmounts: Codable, Equatable, Sendable {
     }
 }
 
+/// Calendar-aligned usage totals for the popover's "Data Usage" summary:
+/// traffic accumulated since midnight (today) and since the 1st of the month.
+struct StatisticsUsageSummary: Sendable, Equatable {
+    var today: StatisticsTrafficAmounts = .init()
+    var month: StatisticsTrafficAmounts = .init()
+
+    static let empty = StatisticsUsageSummary()
+}
+
 struct StatisticsArchive: Codable, Sendable {
     static let currentAppTrafficSchemaVersion = 3
 

--- a/Sources/Netfluss/StatisticsStore.swift
+++ b/Sources/Netfluss/StatisticsStore.swift
@@ -235,6 +235,26 @@ actor StatisticsStore {
         )
     }
 
+    /// Calendar-aligned "today" (since midnight) and "this month" (since the
+    /// 1st) totals summed across ALL adapters from the daily rollups. Matches
+    /// the Statistics window's totals, which likewise count every adapter
+    /// (including tunnels/VPN). Cheap — sums at most ~31 daily buckets — so it
+    /// is safe to call on every refresh tick.
+    func usageSummary(now: Date) -> StatisticsUsageSummary {
+        let todayStart = calendar.startOfDay(for: now)
+        let monthStart = calendar.dateInterval(of: .month, for: now)?.start ?? todayStart
+        let todayKeys = Self.dayKeys(from: todayStart, to: now, calendar: calendar)
+        let monthKeys = Self.dayKeys(from: monthStart, to: now, calendar: calendar)
+
+        func total(for keys: [String]) -> StatisticsTrafficAmounts {
+            aggregate(items: archive.adapterDaily, keys: keys)
+                .values
+                .reduce(into: StatisticsTrafficAmounts()) { $0.merge($1) }
+        }
+
+        return StatisticsUsageSummary(today: total(for: todayKeys), month: total(for: monthKeys))
+    }
+
     private func makeReport(
         range: StatisticsRange,
         displayTitle: String,

--- a/Sources/Netfluss/StatisticsStore.swift
+++ b/Sources/Netfluss/StatisticsStore.swift
@@ -128,7 +128,8 @@ actor StatisticsStore {
         for range: StatisticsRange,
         now: Date,
         customAdapterNames: [String: String],
-        hiddenApps: Set<String>
+        hiddenApps: Set<String>,
+        excludeTunnels: Bool
     ) -> StatisticsReport {
         let adapterSource: [String: [String: StatisticsTrafficAmounts]]
         let appSource: [String: [String: StatisticsTrafficAmounts]]
@@ -180,7 +181,8 @@ actor StatisticsStore {
             appSource: appSource,
             relevantKeys: relevantKeys,
             customAdapterNames: customAdapterNames,
-            hiddenApps: hiddenApps
+            hiddenApps: hiddenApps,
+            excludeTunnels: excludeTunnels
         )
     }
 
@@ -189,7 +191,8 @@ actor StatisticsStore {
         customEnd: Date,
         now: Date,
         customAdapterNames: [String: String],
-        hiddenApps: Set<String>
+        hiddenApps: Set<String>,
+        excludeTunnels: Bool
     ) -> StatisticsReport {
         let boundedEnd = min(max(customStart, customEnd), now)
         let boundedStart = min(customStart, boundedEnd)
@@ -231,16 +234,17 @@ actor StatisticsStore {
             appSource: appSource,
             relevantKeys: relevantKeys,
             customAdapterNames: customAdapterNames,
-            hiddenApps: hiddenApps
+            hiddenApps: hiddenApps,
+            excludeTunnels: excludeTunnels
         )
     }
 
     /// Calendar-aligned "today" (since midnight) and "this month" (since the
-    /// 1st) totals summed across ALL adapters from the daily rollups. Matches
-    /// the Statistics window's totals, which likewise count every adapter
-    /// (including tunnels/VPN). Cheap — sums at most ~31 daily buckets — so it
-    /// is safe to call on every refresh tick.
-    func usageSummary(now: Date) -> StatisticsUsageSummary {
+    /// 1st) totals from the daily rollups. `excludeTunnels` drops VPN/tunnel
+    /// adapters (utun/ipsec/ppp/tun/tap) so the popover's Data Usage total agrees
+    /// with the live Download/Upload totals when that preference is on. Cheap —
+    /// sums at most ~31 daily buckets — safe to call on every refresh tick.
+    func usageSummary(now: Date, excludeTunnels: Bool) -> StatisticsUsageSummary {
         let todayStart = calendar.startOfDay(for: now)
         let monthStart = calendar.dateInterval(of: .month, for: now)?.start ?? todayStart
         let todayKeys = Self.dayKeys(from: todayStart, to: now, calendar: calendar)
@@ -248,6 +252,7 @@ actor StatisticsStore {
 
         func total(for keys: [String]) -> StatisticsTrafficAmounts {
             aggregate(items: archive.adapterDaily, keys: keys)
+                .filter { !(excludeTunnels && AdapterClassifier.isTunnelInterface(named: $0.key)) }
                 .values
                 .reduce(into: StatisticsTrafficAmounts()) { $0.merge($1) }
         }
@@ -266,12 +271,21 @@ actor StatisticsStore {
         appSource: [String: [String: StatisticsTrafficAmounts]],
         relevantKeys: [String],
         customAdapterNames: [String: String],
-        hiddenApps: Set<String>
+        hiddenApps: Set<String>,
+        excludeTunnels: Bool
     ) -> StatisticsReport {
         let coverageStart = earliestCoverageDate()
+        // Full per-adapter aggregate — feeds the adapter list, which always shows
+        // every adapter (tunnels included, per the setting's documented behaviour).
         let adapterTotals = aggregate(items: adapterSource, keys: relevantKeys)
+        // When excluding tunnels, drop those adapters once at the source so the
+        // headline totals and the timeline chart agree; the adapter list is untouched.
+        let totalsSource = excludeTunnels
+            ? adapterSource.mapValues { $0.filter { !AdapterClassifier.isTunnelInterface(named: $0.key) } }
+            : adapterSource
+        let totalsAmounts = aggregate(items: totalsSource, keys: relevantKeys)
         let appTotals = aggregate(items: appSource, keys: relevantKeys)
-        let timeline = timelinePoints(granularity: timelineGranularity, source: adapterSource, keys: relevantKeys)
+        let timeline = timelinePoints(granularity: timelineGranularity, source: totalsSource, keys: relevantKeys)
 
         let adapters = topAdapters(from: adapterTotals, customAdapterNames: customAdapterNames)
         let topDownloadApps = appRows(
@@ -296,8 +310,8 @@ actor StatisticsStore {
             coverageStart: coverageStart,
             lastAdapterSampleAt: archive.lastAdapterSampleAt,
             lastAppSampleAt: archive.lastAppSampleAt,
-            totalDownloadBytes: adapterTotals.values.reduce(0) { $0 + $1.downloadBytes },
-            totalUploadBytes: adapterTotals.values.reduce(0) { $0 + $1.uploadBytes },
+            totalDownloadBytes: totalsAmounts.values.reduce(0) { $0 + $1.downloadBytes },
+            totalUploadBytes: totalsAmounts.values.reduce(0) { $0 + $1.uploadBytes },
             timeline: timeline,
             adapters: adapters,
             topDownloadApps: topDownloadApps,

--- a/Sources/Netfluss/StatisticsView.swift
+++ b/Sources/Netfluss/StatisticsView.swift
@@ -28,6 +28,7 @@ struct StatisticsView: View {
     @EnvironmentObject private var monitor: NetworkMonitor
     @AppStorage("collectStatistics") private var collectStatistics: Bool = false
     @AppStorage("collectAppStatistics") private var collectAppStatistics: Bool = true
+    @AppStorage("excludeTunnelAdaptersFromTotals") private var excludeTunnelAdapters: Bool = false
 
     @State private var range: StatisticsRange = .last24Hours
     @State private var customRangeActive = false
@@ -67,6 +68,9 @@ struct StatisticsView: View {
             statisticsManager.refreshCurrentReport()
         }
         .onChange(of: collectAppStatistics) { _ in
+            statisticsManager.refreshCurrentReport()
+        }
+        .onChange(of: excludeTunnelAdapters) { _ in
             statisticsManager.refreshCurrentReport()
         }
         .onReceive(refreshTimer) { _ in

--- a/Sources/Netfluss/StatusBarController.swift
+++ b/Sources/Netfluss/StatusBarController.swift
@@ -795,6 +795,7 @@ final class StatusBarController: NSObject, NSPopoverDelegate, NSMenuDelegate {
     private func updateDetailMonitoring() {
         let isVisible = popover.isShown || pinnedWindowController.isVisible
         monitor.setDetailMonitoringEnabled(isVisible)
+        statisticsManager.setLiveSummaryActive(isVisible)
         wifiManager.setActive(isVisible && UserDefaults.standard.bool(forKey: "showWifiSwitcher"))
     }
 

--- a/Sources/Netfluss/UsageSummaryView.swift
+++ b/Sources/Netfluss/UsageSummaryView.swift
@@ -1,0 +1,161 @@
+// Copyright (C) 2026 Rana GmbH
+//
+// This file is part of Netfluss.
+//
+// Netfluss is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Netfluss is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Netfluss. If not, see <https://www.gnu.org/licenses/>.
+
+import SwiftUI
+import AppKit
+
+/// Popover "Data Usage" section: a compact upload / download / total summary for
+/// today and the current calendar month, read from the historical statistics
+/// the app already collects. Only rendered when statistics collection is on (see
+/// `MenuBarView.isSectionVisible`), so it never needs an empty/off state itself.
+struct UsageSummarySection: View {
+    @EnvironmentObject private var statisticsManager: StatisticsManager
+    @Environment(\.appTheme) private var theme
+    @State private var isHoveringStats = false
+
+    /// Cumulative-byte formatter, matching the Statistics window
+    /// (`StatisticsView.byteFormatter`) so the two surfaces read identically.
+    private static let byteFormatter: ByteCountFormatter = {
+        let formatter = ByteCountFormatter()
+        formatter.allowedUnits = [.useKB, .useMB, .useGB, .useTB]
+        formatter.countStyle = .decimal
+        formatter.includesUnit = true
+        formatter.isAdaptive = true
+        formatter.zeroPadsFractionDigits = false
+        return formatter
+    }()
+
+    private func formatted(_ bytes: UInt64) -> String {
+        Self.byteFormatter.string(fromByteCount: Int64(clamping: bytes))
+    }
+
+    var body: some View {
+        let summary = statisticsManager.usageSummary
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 6) {
+                Text("Data Usage")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 8)
+                Button {
+                    StatisticsWindowController.shared.show(manager: statisticsManager)
+                } label: {
+                    Image(systemName: "chart.xyaxis.line")
+                        .font(.system(size: 11))
+                        .foregroundStyle(isHoveringStats ? Color.primary : Color.secondary)
+                        .animation(.easeInOut(duration: 0.12), value: isHoveringStats)
+                }
+                .buttonStyle(.borderless)
+                .help("Bandwidth Statistics")
+                .onHover { hovering in
+                    guard hovering != isHoveringStats else { return }
+                    isHoveringStats = hovering
+                    if hovering {
+                        NSCursor.pointingHand.push()
+                    } else {
+                        NSCursor.pop()
+                    }
+                }
+                .onDisappear {
+                    if isHoveringStats {
+                        NSCursor.pop()
+                        isHoveringStats = false
+                    }
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.top, 8)
+            .padding(.bottom, 6)
+
+            Grid(alignment: .trailing, horizontalSpacing: 14, verticalSpacing: 7) {
+                GridRow {
+                    Text("")
+                        .gridColumnAlignment(.leading)
+                    columnHeader("Today")
+                    columnHeader("This Month")
+                }
+                usageRow(
+                    "Upload",
+                    icon: "arrow.up",
+                    color: uploadAccentColor(for: theme),
+                    today: summary.today.uploadBytes,
+                    month: summary.month.uploadBytes
+                )
+                usageRow(
+                    "Download",
+                    icon: "arrow.down",
+                    color: downloadAccentColor(for: theme),
+                    today: summary.today.downloadBytes,
+                    month: summary.month.downloadBytes
+                )
+                Divider()
+                    .gridCellColumns(3)
+                usageRow(
+                    "Total",
+                    icon: nil,
+                    color: .primary,
+                    today: summary.today.totalBytes,
+                    month: summary.month.totalBytes,
+                    emphasized: true
+                )
+            }
+            .padding(.horizontal, 12)
+            .padding(.bottom, 10)
+        }
+        // Refresh when the section becomes visible so the numbers are current
+        // even after an idle stretch with no new adapter deltas. Live updates
+        // while the popover stays open are driven by StatisticsManager.
+        .onAppear { statisticsManager.refreshUsageSummary() }
+    }
+
+    private func columnHeader(_ key: String) -> some View {
+        Text(LocalizedStringKey(key))
+            .font(.system(size: 9, weight: .medium))
+            .foregroundStyle(.secondary)
+            .tracking(0.5)
+    }
+
+    @ViewBuilder
+    private func usageRow(
+        _ titleKey: String,
+        icon: String?,
+        color: Color,
+        today: UInt64,
+        month: UInt64,
+        emphasized: Bool = false
+    ) -> some View {
+        let weight: Font.Weight = emphasized ? .semibold : .regular
+        GridRow {
+            HStack(spacing: 6) {
+                Image(systemName: icon ?? "circle")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(color)
+                    .frame(width: 12)
+                    .opacity(icon == nil ? 0 : 1)
+                Text(LocalizedStringKey(titleKey))
+                    .font(.system(size: 11, weight: weight))
+                    .foregroundStyle(emphasized ? Color.primary : Color.secondary)
+            }
+            Text(formatted(today))
+                .font(.system(size: 11, weight: weight))
+                .monospacedDigit()
+            Text(formatted(month))
+                .font(.system(size: 11, weight: weight))
+                .monospacedDigit()
+        }
+    }
+}

--- a/Sources/Netfluss/UsageSummaryView.swift
+++ b/Sources/Netfluss/UsageSummaryView.swift
@@ -116,10 +116,6 @@ struct UsageSummarySection: View {
             .padding(.horizontal, 12)
             .padding(.bottom, 10)
         }
-        // Refresh when the section becomes visible so the numbers are current
-        // even after an idle stretch with no new adapter deltas. Live updates
-        // while the popover stays open are driven by StatisticsManager.
-        .onAppear { statisticsManager.refreshUsageSummary() }
     }
 
     private func columnHeader(_ key: String) -> some View {
@@ -141,11 +137,15 @@ struct UsageSummarySection: View {
         let weight: Font.Weight = emphasized ? .semibold : .regular
         GridRow {
             HStack(spacing: 6) {
-                Image(systemName: icon ?? "circle")
-                    .font(.system(size: 10, weight: .semibold))
-                    .foregroundStyle(color)
-                    .frame(width: 12)
-                    .opacity(icon == nil ? 0 : 1)
+                if let icon {
+                    Image(systemName: icon)
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(color)
+                        .frame(width: 12)
+                        .accessibilityHidden(true)
+                } else {
+                    Color.clear.frame(width: 12, height: 1)
+                }
                 Text(LocalizedStringKey(titleKey))
                     .font(.system(size: 11, weight: weight))
                     .foregroundStyle(emphasized ? Color.primary : Color.secondary)
@@ -157,5 +157,6 @@ struct UsageSummarySection: View {
                 .font(.system(size: 11, weight: weight))
                 .monospacedDigit()
         }
+        .accessibilityElement(children: .combine)
     }
 }


### PR DESCRIPTION
This pull request introduces a new "Data Usage" summary section to the popover, allowing users to view today's and this month's upload, download, and total data usage. The section is user-configurable and only appears if historical statistics collection is enabled. The implementation includes UI updates, localization for multiple languages, and backend support for efficient data summary computation.

**Popover UI and Feature Additions:**
- Added a new `usage` section (`Data Usage`) to the popover, including UI logic to display it and a new `UsageSummarySection` view. The section is only visible if both the "show usage summary" toggle and historical statistics collection are enabled. [[1]](diffhunk://#diff-c065cf0249560c5343f4b0808250fbcedaad57a855113b2c6e988ab18b6613e5R201) [[2]](diffhunk://#diff-c065cf0249560c5343f4b0808250fbcedaad57a855113b2c6e988ab18b6613e5L212-R219) [[3]](diffhunk://#diff-c065cf0249560c5343f4b0808250fbcedaad57a855113b2c6e988ab18b6613e5R233) [[4]](diffhunk://#diff-838d9bbdb18dc8d6b7fc0c6dea1c12136404733b12c3d940d77b96daf1bdff3aR50-R51) [[5]](diffhunk://#diff-838d9bbdb18dc8d6b7fc0c6dea1c12136404733b12c3d940d77b96daf1bdff3aR150) [[6]](diffhunk://#diff-838d9bbdb18dc8d6b7fc0c6dea1c12136404733b12c3d940d77b96daf1bdff3aR173-R175)
- Introduced the `showUsageSummary` preference, integrated with `AppStorage`, and ensured it is persisted and togglable in user preferences. [[1]](diffhunk://#diff-f2e4973681cfb647768c6605622d3db8213f1493ae27476540ffa475c7b29d7aR75) [[2]](diffhunk://#diff-0bf6dc5f5391c193381c8626306ca38f17cf865883f415a5d9d9efcff7dbc8bbR265) [[3]](diffhunk://#diff-0bf6dc5f5391c193381c8626306ca38f17cf865883f415a5d9d9efcff7dbc8bbR492-R499) [[4]](diffhunk://#diff-0bf6dc5f5391c193381c8626306ca38f17cf865883f415a5d9d9efcff7dbc8bbR1453-R1454) [[5]](diffhunk://#diff-0bf6dc5f5391c193381c8626306ca38f17cf865883f415a5d9d9efcff7dbc8bbR1472-R1473) [[6]](diffhunk://#diff-0bf6dc5f5391c193381c8626306ca38f17cf865883f415a5d9d9efcff7dbc8bbL1507-R1520)

**Backend and Logic Enhancements:**
- Updated `StatisticsManager` to maintain and refresh a live `usageSummary` object, with logic to recompute the summary only when the section is visible and statistics collection is enabled. Added token-guarding to prevent stale async updates. [[1]](diffhunk://#diff-e83fa51321f2a29cca8f27e21428d39577b479bb70793bee748a8a51aa1259a1R37) [[2]](diffhunk://#diff-e83fa51321f2a29cca8f27e21428d39577b479bb70793bee748a8a51aa1259a1R85-R94) [[3]](diffhunk://#diff-e83fa51321f2a29cca8f27e21428d39577b479bb70793bee748a8a51aa1259a1R157-R176) [[4]](diffhunk://#diff-e83fa51321f2a29cca8f27e21428d39577b479bb70793bee748a8a51aa1259a1R207-R234)
- Ensured that tunnel/VPN adapters can be excluded from totals for consistency with other statistics. [[1]](diffhunk://#diff-e83fa51321f2a29cca8f27e21428d39577b479bb70793bee748a8a51aa1259a1R106-R114) [[2]](diffhunk://#diff-e83fa51321f2a29cca8f27e21428d39577b479bb70793bee748a8a51aa1259a1R131-R140)

**Localization:**
- Added all relevant strings for the new section and its settings in English, German, Simplified Chinese, and Traditional Chinese resource files. This includes section titles, toggle descriptions, and tooltips. [[1]](diffhunk://#diff-b55642175f07dfcc7dfb065070a0fba8974b9359ec1acfeca09e638e8b00a87bR211-R216) [[2]](diffhunk://#diff-2f412a9462708a10b18c3c3d2e3206b1538ad28cc32aa289789332553d02ca0aR211-R216) [[3]](diffhunk://#diff-a3ab4fcd2ed5c1f39b2cc00d6a0a0bce81233fcf534d140cb1891b0c8068e337R211-R216) [[4]](diffhunk://#diff-5e8a2da37980b32cf2d5ebb4f36ecb0e65a28985218a4ff27d52c0627eb1a18bR211-R216) [[5]](diffhunk://#diff-6b42b0a6ad33d8e2c36f5cd2fa3818f843b2846cc9ee6ad6338eb1181f968af3R211-R216) [[6]](diffhunk://#diff-ae16a5d0e231d94ae5913f9cf2c69fac12b98158f7e2b9b2b43f3c1b5dbaafeaR211-R216) [[7]](diffhunk://#diff-8c6dd6d4c3e4d2778cebebef371e19422b662865aed6d94f78ca79d4fda50283R211-R216) [[8]](diffhunk://#diff-11b4b65732e1d6c6e89f3695bb0ae3b3637261bd96539f32ab6e200edc20dbd7R211-R216)

These changes collectively provide a new, user-friendly way to monitor data usage trends directly from the popover, with robust backend support and internationalization.

---

Preview:

<img width="500"  alt="Image" src="https://github.com/user-attachments/assets/1b354f16-7a33-4391-ad1b-3e67490b4a86" />

https://github.com/user-attachments/assets/fbb8db40-f038-412c-9b81-7cde6fb24f00